### PR TITLE
Add build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,39 @@
-
 # HOTOSM Website
 
-This repo is the codebase for the main Humanitarian OpenStreetMap Team website. Under active development to rebuild and redesign. See `gh-pages` branch for Jekyll code. If looking for the previous Drupal codebase, see the current `master` branch. 
+This repo is the codebase for the main Humanitarian OpenStreetMap Team website. Under active development to rebuild and redesign. See `gh-pages` branch for Jekyll code. If looking for the previous Drupal codebase, see the current `master` branch.
 
- - See the [issues queue](https://github.com/hotosm/hotosm-website/issues) for all discussions and tasks. 
+ - See the [issues queue](https://github.com/hotosm/hotosm-website/issues) for all discussions and tasks.
  - Chat available on [HOTOSM Slack](https://slack.hotosm.org/) within the #hotosm-website channel.
 
-Preview site at: http://hotosm.github.io/hotosm-website/. 
+Preview site at: https://hotosm.github.io/hotosm-website/.
 
 ## Getting Started with Development
 
-This site is a Jekyll site. To get started on GNU/Linux, Unix, or macOS:
+This site uses [Jekyll](https://jekyllrb.com/). To get started on GNU/Linux, Unix, or macOS, you must meet the following requirements:
 
-Requirements:
   * Ruby 2.2.5 or above
   * RubyGems
   * GCC and Make
 
-Jekyll installation with RubyGems: 
+First, install [bundler](https://bundler.io/).
 
 ```
-gem install jekyll
+gem install bundler
 ```
 
-Running Jekyll: 
+Next, use bundler to install the build dependencies:
 
 ```
-jekyll serve --livereload
+bundle install
 ```
+
+Then, start Jekyll with bundler (this resolves any dependency issues you may have):
+
+```
+bundle exec jekyll serve -- --livereload
+```
+
+Finally, navigate to http://127.0.0.1:4000/ and you should see the new website!
 
 ## Website issues
 Please use the issue tracker at https://github.com/hotosm/hotosm-website/issues to report bugs, develop ideas, ask questions or give feedback. Thank you!
-


### PR DESCRIPTION
This pull request fixes #135. Also removed some unneeded whitespace and changed `http` to `https`.

Let me know if I should add more information to the README. These are all the steps I had to take in order to get a working version of the website.

Note that `jekyll serve` by itself will not work when the user has a newer version of one of the dependencies in `Gemfile.lock`. This is why I use [`bundle exec`](https://bundler.io/man/bundle-exec.1.html) here.