### PR TITLE
add dev CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www-dev.hotosm.org


### PR DESCRIPTION
Adds CNAME file to point to www-dev.hotosm.org. DNS is set on AWS so as soon as this is merged, this should be set. 

Fix #139 for now