### PR TITLE
add sorting based on position for highlighted projects, add sort by date for remaining

### DIFF
--- a/_layouts/project-index.html
+++ b/_layouts/project-index.html
@@ -34,7 +34,8 @@ layout: default
 
     <div class="project-index-highlights">
 
-      {% for project in site.projects limit:3 %}
+      {% assign sorted_projects = site.projects | sort:"position" %}
+      {% for project in sorted_projects limit:3 %}
         {% include blocks/project-highlight.html %}
       {% endfor %}
 
@@ -46,7 +47,8 @@ layout: default
 
     <div class="project-index-all">
 
-      {% for project in site.projects %}
+      {% assign sorted_projects = site.projects | sort:"date" | reverse %}
+      {% for project in sorted_projects %}
         {% include blocks/project-thumb.html %}
       {% endfor %}
 


### PR DESCRIPTION
This adds the sorting by position for the highlighted projects and sorts by date for the remainder. Thinking that sorting by date is probably the best method for the project index. Right now this is sorted on document date, not the duration dates. 