### PR TITLE
adjust get invovled page blocks and text

### DIFF
--- a/_layouts/get-involved.html
+++ b/_layouts/get-involved.html
@@ -41,34 +41,34 @@ layout: default
     <div class="container">
 
       <div class="module-group top-image">
-        <a class="module link-through light" href="/donate" id="support-programs">
+        <a class="module link-through light" href="{{ page.block-1.Link }}" id="support-programs">
           <div class="module-image">
-            <img src="{{ page.Donate.Image }}">
+            <img src="{{ page.block-1.Image }}">
           </div>
           <div class="module-details">
-            <h3>Donate</h3>
-            <div class="module-text">{{ page.Donate.Text | markdownify }}</div>
-            <p class="module-cta">Donate now</p>
+            <h3>{{ page.block-1.Title | markdownify }}</h3>
+            <div class="module-text">{{ page.block-1.Text | markdownify }}</div>
+            <p class="module-cta">{{ page.block-1.Action-text | markdownify }}</p>
           </div>
         </a>
-        <a class="module link-through light" href="/working-groups" id="working-groups">
+        <a class="module link-through light" href="{{ page.block-2.Link }}" id="support-programs">
           <div class="module-image">
-            <img src="{{ page['Working Groups'].Image }}">
+            <img src="{{ page.block-2.Image }}">
           </div>
           <div class="module-details">
-            <h3>Working Groups</h3>
-            <div class="module-text">{{ page['Working Groups'].Text | markdownify }}</div>
-            <p class="module-cta">Learn more</p>
+            <h3>{{ page.block-2.Title | markdownify }}</h3>
+            <div class="module-text">{{ page.block-2.Text | markdownify }}</div>
+            <p class="module-cta">{{ page.block-2.Action-text | markdownify }}</p>
           </div>
         </a>
-        <a class="module link-through light" href="/jobs" id="support-programs">
+        <a class="module link-through light" href="{{ page.block-3.Link }}" id="support-programs">
           <div class="module-image">
-            <img src="{{ page.Jobs.Image }}">
+            <img src="{{ page.block-3.Image }}">
           </div>
           <div class="module-details">
-            <h3>Jobs</h3>
-            <div class="module-text">{{ page.Jobs.Text | markdownify }}</div>
-            <p class="module-cta">See current vacancies</p>
+            <h3>{{ page.block-3.Title | markdownify }}</h3>
+            <div class="module-text">{{ page.block-3.Text | markdownify }}</div>
+            <p class="module-cta">{{ page.block-3.Action-text | markdownify }}</p>
           </div>
         </a>
       </div>

--- a/get-involved.markdown
+++ b/get-involved.markdown
@@ -2,18 +2,24 @@
 title: Get Involved
 date: 2018-02-06 15:18:00 Z
 position: 7
-Donate:
-  Text: Donec id elit non mi porta gravida at eget metus. Cum sociis natoque penatibus
-    et magnis dis parturient montes, nascetur ridiculus mus.
-  Image: https://source.unsplash.com/collection/207682/800x600?v=1
-Working Groups:
-  Text: Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
-    Nullam quis risus eget urna mollis ornare vel eu leo.
+block-1:
+  Title: Working Groups
+  Text: "HOT's working groups are open to everyone and are where the wider HOT/OSM community can come together or plan and work on projects that have a specific area of interest in support of HOT's wider community. In these groups is where HOT's policy and plans are discussed in a public, collaborative, participatory way."
+  Action-text: Learn More
   Image: https://source.unsplash.com/collection/1118917/800x800?v=1
-Jobs:
-  Text: Nulla vitae elit libero, a pharetra augue. Donec ullamcorper nulla non metus
-    auctor fringilla.
+  Link: /working-groups
+block-2:
+  Title: Volunteer
+  Text: Interested in volunteering? You can volunteer by participating in mapping activities or contributing time by supporting training materials or helping develop and maintain our tools
+  Action-text: See more ways you can volunteer
+  Image: https://source.unsplash.com/collection/207682/800x600?v=1
+  Link: /volunteer
+block-3:
+  Title: Join the conversation online
+  Text: Sign up for the mailiing list below or join the community online via Slack or IRC. On Slack, you can join topic based channels to hear about what is going on, ask questions, or communicate with community members.
+  Action-text: Get connected now
   Image: https://source.unsplash.com/collection/851614/800x600?v=1
+  Link: https://slack.hotosm.org/
 layout: get-involved
 ---
 


### PR DESCRIPTION
This adjusts the Get Involved page to factor for feedback and suggestions made. Adjusts the sections to be: 

- Working Groups
- Volunteer
- Connect with Slack

Goal is to help make this page more about volunteering. 

![humanitarian openstreetmap team get involved 2018-03-27 13-45-56](https://user-images.githubusercontent.com/796838/37968158-4a2998ea-31c5-11e8-8792-85ad41e4ecd8.png)

Still to do: 

- [ ] consider what button labels and links are at the top section for `Learn how to get involved as a:`
- [ ] review text
- [ ] add photos