### PR TITLE
Hook up links to associated projects and working groups

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,35 +44,37 @@ defaults:
   values:
     permalink: updates/:title/
     layout: news-item
-    Summary Text: 
-    Feature Image: 
-    Person: 
+    Summary Text:
+    Feature Image:
+    Person:
     Working Group:
     - ''
     Country:
+    - ''
+    Project:
     - ''
 - scope:
     path: ''
     type: people
   values:
     layout: person
-    Photo: 
+    Photo:
     Member Type:
-      Is Staff: 
-      Is Voting Member: 
-      Is Board Member: 
-    Job Title: 
+      Is Staff:
+      Is Voting Member:
+      Is Board Member:
+    Job Title:
     Working Group:
     - ''
     Project:
     - ''
-    Country: 
+    Country:
     Social Media (Full URL):
-      OSM: 
-      Twitter: 
-      LinkedIn: 
-      Facebook: 
-      Instagram: 
+      OSM:
+      Twitter:
+      LinkedIn:
+      Facebook:
+      Instagram:
 - scope:
     path: ''
     type: impact-areas
@@ -84,37 +86,37 @@ defaults:
     type: tools
   values:
     layout: impact-area
-    Tool URL: 
+    Tool URL:
 - scope:
     path: ''
     type: jobs
   values:
     layout: page
-    Deadline Date: 
-    Place of Work: 
+    Deadline Date:
+    Place of Work:
 - scope:
     path: ''
     type: where-we-work
   values:
     layout: country
     Contact Person:
-      Name: 
-      Title: 
-      Email: 
-      Phone: 
+      Name:
+      Title:
+      Email:
+      Phone:
     Location:
-      Location Name: 
-      Address: 
-      Phone: 
-      Map Link: 
+      Location Name:
+      Address:
+      Phone:
+      Map Link:
 - scope:
     path: ''
     type: projects
   values:
     layout: project-item
-    Project Summary Text: 
-    Feature Image: 
-    Is Community-Led: 
+    Project Summary Text:
+    Feature Image:
+    Is Community-Led:
     Country:
     - ''
     Impact Area:
@@ -124,14 +126,14 @@ defaults:
     Partner:
     - ''
     Duration:
-      Start Date: 
+      Start Date:
       End Date: Ongoing
 email: info@hotosm.org
 description: Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for Google search
   results) and in your feed.xml site description.
-baseurl: 
-url: 
+baseurl:
+url:
 twitter_username: hotosm
 github_username: hotosm
 markdown: kramdown

--- a/_layouts/news-item.html
+++ b/_layouts/news-item.html
@@ -79,21 +79,26 @@ layout: default
           <h5>Working Groups</h5>
           <ul>
             {% for group in page['Working Group'] %}
-              <li><a href="#">{{ group }}</a></li>
+              <li><a href="/working-groups">{{ group }}</a></li>
             {% endfor %}
           </ui>
         </div>
       {% endif %}
 
-      <div class="meta-item news-projects">
-        {% if page['Working Group'] %}
+      {% if page['Project'][0] != '' %}
+        <div class="meta-item news-projects">
           <h5>Associated Projects</h5>
           <ul>
-            <li><a href="#">Project Name</a></li>
-            <li><a href="#">Another Project Name</a></li>
+            {% for news-project in page.Project %}
+              {% for project in site.projects %}
+                {% if news-project == project.title %}
+                  <li><a href="{{ project.url }}">{{ project.title }}</a></li>
+                {% endif %}
+              {% endfor %}
+            {% endfor %}
           </ui>
-        {% endif %}
-      </div>
+        </div>
+      {% endif %}
 
     </aside>
   </div>

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -116,7 +116,7 @@ layout: default
             <h5>Working Groups</h5>
             <ul>
               {% for group in page['Working Group'] %}
-                <li><a href="#">{{ group }}</a></li>
+                <li><a href="/working-groups">{{ group }}</a></li>
               {% endfor %}
             </ui>
           </div>

--- a/_layouts/what-we-do.html
+++ b/_layouts/what-we-do.html
@@ -30,7 +30,7 @@ layout: default
           <div class="highlight-options">
             <h5>Projects to check out</h5>
             <ul>
-              {% for project in page['Block 1'].Projects %}
+              {% for project in page['Block 1'].Project %}
                 <li><a href="{{ project.url }}">{{ project }}</a></li>
               {% endfor %}
             </ul>
@@ -53,7 +53,7 @@ layout: default
           <div class="highlight-options">
             <h5>Projects to check out</h5>
             <ul>
-              {% for project in page['Block 2'].Projects %}
+              {% for project in page['Block 2'].Project %}
                 <li><a href="{{ project.url }}">{{ project }}</a></li>
               {% endfor %}
             </ul>
@@ -76,7 +76,7 @@ layout: default
           <div class="highlight-options">
             <h5>Projects to check out</h5>
             <ul>
-              {% for project in page['Block 3'].Projects %}
+              {% for project in page['Block 3'].Project %}
                 <li><a href="{{ project.url }}">{{ project }}</a></li>
               {% endfor %}
             </ul>

--- a/_people/amelia-hunt.md
+++ b/_people/amelia-hunt.md
@@ -6,7 +6,7 @@ Working Group:
 - Community
 - Communications
 Project:
-- Dar Ramani Huria - Dar Open Map
+- Dar Ramani Huria — Dar Open Map
 Social Media (Full URL):
   LinkedIn: https://www.linkedin.com/in/ameliahunt/
   Twitter: https://twitter.com/ameliahunt92

--- a/_people/dale-kunce.md
+++ b/_people/dale-kunce.md
@@ -20,7 +20,7 @@ Project:
 - Missing Maps
 - Tasking Manager
 - Hurricane Patricia
-- Dar Ramani Huria - Dar Open Map
+- Dar Ramani Huria — Dar Open Map
 - Sri Lanka Flooding 2016
 - West Africa Ebola Epidemic
 - OpenAerialMap

--- a/_people/geoffrey-kateregga.md
+++ b/_people/geoffrey-kateregga.md
@@ -11,7 +11,7 @@ Working Group:
 - Activation
 Project:
 - Mapping Financial Inclusion in Uganda
-- Dar Ramani Huria - Dar Open Map
+- Dar Ramani Huria — Dar Open Map
 Country: Uganda
 Social Media (Full URL):
   Twitter: https://twitter.com/@kateregga1

--- a/_people/paul-uithol.md
+++ b/_people/paul-uithol.md
@@ -12,7 +12,7 @@ Project:
 - OpenMapKit
 - Hurricane Matthew
 - 'LEGIT: Supporting decentralization in Liberian cities'
-- Dar Ramani Huria - Dar Open Map
+- Dar Ramani Huria — Dar Open Map
 Country: Netherlands
 Social Media (Full URL):
   LinkedIn: https://nl.linkedin.com/in/pauluithol

--- a/_people/sophie-lafayette.md
+++ b/_people/sophie-lafayette.md
@@ -3,7 +3,7 @@ title: Sophie Lafayette
 date: 2015-07-14 16:45:43 Z
 permalink: users/sophie_lafayette
 Project:
-- Dar Ramani Huria - Dar Open Map
+- Dar Ramani Huria — Dar Open Map
 Country: Tanzania
 Social Media (Full URL):
   LinkedIn: https://tz.linkedin.com/in/sophielafayette

--- a/_people/steven-bukulu.md
+++ b/_people/steven-bukulu.md
@@ -7,7 +7,7 @@ Working Group:
 - Communications
 - Community
 Project:
-- Dar Ramani Huria - Dar Open Map
+- Dar Ramani Huria — Dar Open Map
 Country: Uganda
 Social Media (Full URL):
   LinkedIn: https://www.linkedin.com/profile/view?id=AAIAABQzoywBw1S9LZAa67zFg0RCDnU9WOf2Ex0&trk=nav_responsive_tab_profile_pic

--- a/_posts/2010-01-12-haiti-openstreetmap-response-by-mikel.md
+++ b/_posts/2010-01-12-haiti-openstreetmap-response-by-mikel.md
@@ -5,7 +5,7 @@ permalink: updates/2010-01-12_haiti_openstreetmap_response_by_mikel
 Summary Text: ''
 Person: Mikel Maron
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 created: 1263318335
 ---

--- a/_posts/2010-02-09-humanitarian-osm-team-haiti-strategy-and-proposal.md
+++ b/_posts/2010-02-09-humanitarian-osm-team-haiti-strategy-and-proposal.md
@@ -4,7 +4,7 @@ date: 2010-02-09 20:56:29 Z
 permalink: updates/2010-02-09_humanitarian_osm_team_haiti_strategy_and_proposal
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1265748989
 ---
 

--- a/_posts/2010-03-02-hot-list-by-mikel.md
+++ b/_posts/2010-03-02-hot-list-by-mikel.md
@@ -4,7 +4,7 @@ date: 2010-03-02 20:55:03 Z
 permalink: updates/2010-03-02_hot_list_by_mikel
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1267563303
 ---
 

--- a/_posts/2010-03-17-humanitarian-openstreetmap-team-deploying-to-haiti-by-mikel.md
+++ b/_posts/2010-03-17-humanitarian-openstreetmap-team-deploying-to-haiti-by-mikel.md
@@ -4,7 +4,7 @@ date: 2010-03-17 18:44:35 Z
 permalink: updates/2010-03-17_humanitarian_openstreetmap_team_deploying_to_haiti_by_mikel
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1268851475
 ---
 

--- a/_posts/2010-03-21-mission-1-recap-of-the-first-week-conducting-training-and-outreach-on-openstreetmap-in-haiti-by-robe.md
+++ b/_posts/2010-03-21-mission-1-recap-of-the-first-week-conducting-training-and-outreach-on-openstreetmap-in-haiti-by-robe.md
@@ -5,7 +5,7 @@ date: 2010-03-21 03:25:18 Z
 permalink: updates/2010-03-21_mission_1_recap_of_the_first_week_conducting_training_and_outreach_on_openstreet
 Person: robert
 Working Group: []
-Projects: []
+Project: []
 created: 1269141918
 ---
 

--- a/_posts/2010-04-08-mission-1-recap-of-the-second-week-conducting-training-and-outreach-on-openstreetmap-in-haiti-by-rob.md
+++ b/_posts/2010-04-08-mission-1-recap-of-the-second-week-conducting-training-and-outreach-on-openstreetmap-in-haiti-by-rob.md
@@ -5,7 +5,7 @@ date: 2010-04-08 03:30:19 Z
 permalink: updates/2010-04-08_mission_1_recap_of_the_second_week_conducting_training_and_outreach_on_openstree
 Person: robert
 Working Group: []
-Projects: []
+Project: []
 created: 1270697419
 ---
 

--- a/_posts/2010-04-17-mission-1-recap-from-third-week-conducting-outreach-and-training-on-osm-in-haiti-by-nicolas.md
+++ b/_posts/2010-04-17-mission-1-recap-from-third-week-conducting-outreach-and-training-on-osm-in-haiti-by-nicolas.md
@@ -5,7 +5,7 @@ date: 2010-04-17 03:30:24 Z
 permalink: updates/2010-04-17_mission_1_recap_from_third_week_conducting_outreach_and_training_on_osm_in_haiti
 Person: Nicolas Chavent
 Working Group: []
-Projects: []
+Project: []
 created: 1271475024
 ---
 

--- a/_posts/2010-05-10-haiti-mission-2-by-mikel.md
+++ b/_posts/2010-05-10-haiti-mission-2-by-mikel.md
@@ -4,7 +4,7 @@ date: 2010-05-10 18:18:59 Z
 permalink: updates/2010-05-10_haiti_mission_2_by_mikel
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1273515539
 ---
 

--- a/_posts/2010-05-19-may-mid-mission-to-haiti-report-from-nicolas-and-dane.md
+++ b/_posts/2010-05-19-may-mid-mission-to-haiti-report-from-nicolas-and-dane.md
@@ -5,7 +5,7 @@ permalink: updates/2010-05-19_may_mid-mission_to_haiti_report_from_nicolas_and_d
 Person: Website Administrator
 Working Group:
 - Technical
-Projects: []
+Project: []
 created: 1274305921
 ---
 

--- a/_posts/2010-06-03-mission-2-report-on-field-trips-to-jacmel-and-leogane.md
+++ b/_posts/2010-06-03-mission-2-report-on-field-trips-to-jacmel-and-leogane.md
@@ -4,7 +4,7 @@ date: 2010-06-03 05:26:27 Z
 permalink: updates/2010-06-03_mission_2_report_on_field_trips_to_jacmel_and_leogane
 Person: Dane Springmeyer
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/4630644202_2c57b16e0c.jpg
 created: 1275542787
 ---

--- a/_posts/2010-06-15-haiti-mission-3-first-day-in-the-un-logistics-base-in-port-au-prince.md
+++ b/_posts/2010-06-15-haiti-mission-3-first-day-in-the-un-logistics-base-in-port-au-prince.md
@@ -5,7 +5,7 @@ permalink: updates/2010-06-15_haiti_mission_3_-_first_day_in_the_un_logistics_ba
 Person: Nicolas Chavent
 Working Group:
 - Communications
-Projects: []
+Project: []
 created: 1276633989
 ---
 

--- a/_posts/2010-06-15-third-deploy-to-haiti-of-the-humanitarian-openstreetmap-team-14-29-june.md
+++ b/_posts/2010-06-15-third-deploy-to-haiti-of-the-humanitarian-openstreetmap-team-14-29-june.md
@@ -4,7 +4,7 @@ date: 2010-06-15 03:53:25 Z
 permalink: updates/2010-06-15_third_deploy_to_haiti_of_the_humanitarian_openstreetmap_team_14-29_june
 Person: Nicolas Chavent
 Working Group: []
-Projects: []
+Project: []
 created: 1276574005
 ---
 

--- a/_posts/2010-06-16-haiti-mission-3-training-day-with-field-workers-of-the-shelter-cluster-organizations.md
+++ b/_posts/2010-06-16-haiti-mission-3-training-day-with-field-workers-of-the-shelter-cluster-organizations.md
@@ -4,7 +4,7 @@ date: 2010-06-16 20:31:31 Z
 permalink: updates/2010-06-16_haiti_mission_3_-_training_day_with_field_workers_of_the_shelter_cluster_organiz
 Person: Nicolas Chavent
 Working Group: []
-Projects: []
+Project: []
 created: 1276720291
 ---
 

--- a/_posts/2010-06-18-haiti-mission-3-training-day-with-haitian-partners-of-the-project-winner.md
+++ b/_posts/2010-06-18-haiti-mission-3-training-day-with-haitian-partners-of-the-project-winner.md
@@ -4,7 +4,7 @@ date: 2010-06-18 20:27:30 Z
 permalink: updates/2010-06-18_haiti_mission_3_-_training_day_with_haitian_partners_of_the_project_winner
 Person: Nicolas Chavent
 Working Group: []
-Projects: []
+Project: []
 created: 1276892850
 ---
 

--- a/_posts/2010-06-19-how-to-improve-our-work-in-haiti-mapmaker-and-osm-thoughts-too-by-mikel.md
+++ b/_posts/2010-06-19-how-to-improve-our-work-in-haiti-mapmaker-and-osm-thoughts-too-by-mikel.md
@@ -4,7 +4,7 @@ date: 2010-06-19 08:33:57 Z
 permalink: updates/2010-06-19_how_to_improve_our_work_in_haiti?_mapmaker_and_osm_thoughts_too_by_mikel
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1276936437
 ---
 

--- a/_posts/2010-06-20-haiti-mission-3-training-day-with-the-iom-community-mobilizers.md
+++ b/_posts/2010-06-20-haiti-mission-3-training-day-with-the-iom-community-mobilizers.md
@@ -4,7 +4,7 @@ date: 2010-06-20 06:39:04 Z
 permalink: updates/2010-06-20_haiti_mission_3_-_training_day_with_the_iom_community_mobilizers
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1277015944
 ---
 

--- a/_posts/2010-06-21-haiti-mission-3-week-1-in-port-au-prince.md
+++ b/_posts/2010-06-21-haiti-mission-3-week-1-in-port-au-prince.md
@@ -5,7 +5,7 @@ permalink: updates/2010-06-21_haiti_mission_3_-_week_1_in_port-au-prince
 Person: Kate Chapman
 Working Group:
 - Training
-Projects: []
+Project: []
 created: 1277085181
 ---
 

--- a/_posts/2010-06-24-haiti-mission-3-jacmel-and-leogane-reports.md
+++ b/_posts/2010-06-24-haiti-mission-3-jacmel-and-leogane-reports.md
@@ -4,7 +4,7 @@ date: 2010-06-24 20:22:40 Z
 permalink: updates/2010-06-24_haiti_mission_3_-_jacmel_and_leogane_reports
 Person: Nicolas Chavent
 Working Group: []
-Projects: []
+Project: []
 created: 1277410960
 ---
 

--- a/_posts/2010-06-27-haiti-mission-3-training-and-mapping-party-in-gonaves.md
+++ b/_posts/2010-06-27-haiti-mission-3-training-and-mapping-party-in-gonaves.md
@@ -4,7 +4,7 @@ date: 2010-06-27 23:11:58 Z
 permalink: updates/2010-06-27_haiti_mission_3_-_training_and_mapping_party_in_gonaÃ¯ves
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1277680318
 ---
 

--- a/_posts/2010-06-28-haiti-mission-3-a-final-mapping-party-in-carrefour-port-au-prince-at-the-base-navale-amiral-killic-a.md
+++ b/_posts/2010-06-28-haiti-mission-3-a-final-mapping-party-in-carrefour-port-au-prince-at-the-base-navale-amiral-killic-a.md
@@ -5,7 +5,7 @@ date: 2010-06-28 20:15:42 Z
 permalink: updates/2010-06-28_haiti_mission_3_-_a_final_mapping_party_in_carrefour_(port_au_prince)_at_the_bas
 Person: Nicolas Chavent
 Working Group: []
-Projects: []
+Project: []
 created: 1277756142
 ---
 

--- a/_posts/2010-06-29-hot-thoughts-by-trevor.md
+++ b/_posts/2010-06-29-hot-thoughts-by-trevor.md
@@ -4,7 +4,7 @@ date: 2010-06-29 01:10:05 Z
 permalink: updates/2010-06-29_hot_thoughts_by_trevor
 Person: Trevor Ellerman
 Working Group: []
-Projects: []
+Project: []
 created: 1277773805
 ---
 

--- a/_posts/2010-08-22-hot-mission-4-to-haiti.md
+++ b/_posts/2010-08-22-hot-mission-4-to-haiti.md
@@ -5,7 +5,7 @@ permalink: updates/2010-08-22_hot_mission_4_to_haiti
 Person: Kate Chapman
 Working Group:
 - Technical
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/4777521706_9a2f8c222d_m.jpg
 created: 1282508303
 ---

--- a/_posts/2010-08-25-pakistan-floods.md
+++ b/_posts/2010-08-25-pakistan-floods.md
@@ -4,7 +4,7 @@ date: 2010-08-25 17:16:19 Z
 permalink: updates/2010-08-25_pakistan_floods
 Person: Harry Wood
 Working Group: []
-Projects: []
+Project: []
 created: 1282756579
 ---
 

--- a/_posts/2010-09-04-pakistan-spot-imagery-coverage-extended.md
+++ b/_posts/2010-09-04-pakistan-spot-imagery-coverage-extended.md
@@ -4,7 +4,7 @@ date: 2010-09-04 07:54:39 Z
 permalink: updates/2010-09-04_pakistan_spot_imagery_coverage_extended
 Person: Harry Wood
 Working Group: []
-Projects: []
+Project: []
 created: 1283586879
 ---
 

--- a/_posts/2010-09-08-fourth-deploy-of-the-hot-to-haiti-camp-mapping-project-with-iom.md
+++ b/_posts/2010-09-08-fourth-deploy-of-the-hot-to-haiti-camp-mapping-project-with-iom.md
@@ -4,7 +4,7 @@ date: 2010-09-08 15:19:28 Z
 permalink: updates/2010-09-08_fourth_deploy_of_the_hot_to_haiti_camp_mapping_project_with_iom
 Person: Nicolas Chavent
 Working Group: []
-Projects: []
+Project: []
 created: 1283959168
 ---
 

--- a/_posts/2010-11-17-maps-for-mozambique.md
+++ b/_posts/2010-11-17-maps-for-mozambique.md
@@ -4,7 +4,7 @@ date: 2010-11-17 18:17:41 Z
 permalink: updates/2010-11-17_maps_for_mozambique
 Person: Iván Sánchez Ortega
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/mozambique_visado.jpg
 created: 1290017861
 ---

--- a/_posts/2010-11-24-hots-proposal-for-the-knight-news-challenge.md
+++ b/_posts/2010-11-24-hots-proposal-for-the-knight-news-challenge.md
@@ -4,7 +4,7 @@ date: 2010-11-24 11:08:58 Z
 permalink: updates/2010-11-24_hot's_proposal_for_the_knight_news_challenge
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1290596938
 ---
 

--- a/_posts/2010-12-31-ivory-coast-post-electoral-crisis.md
+++ b/_posts/2010-12-31-ivory-coast-post-electoral-crisis.md
@@ -4,7 +4,7 @@ date: 2010-12-31 04:00:57 Z
 permalink: updates/2010-12-31_ivory_coast_post_electoral_crisis
 Person: Nicolas Chavent
 Working Group: []
-Projects: []
+Project: []
 created: 1293768057
 ---
 

--- a/_posts/2011-01-14-introducing-cosmha.md
+++ b/_posts/2011-01-14-introducing-cosmha.md
@@ -4,7 +4,7 @@ date: 2011-01-14 06:34:38 Z
 permalink: updates/2011-01-14_introducing_cosmha
 Person: robert
 Working Group: []
-Projects: []
+Project: []
 created: 1294986878
 ---
 

--- a/_posts/2011-01-25-the-new-hot-logo.md
+++ b/_posts/2011-01-25-the-new-hot-logo.md
@@ -4,7 +4,7 @@ date: 2011-01-25 10:47:41 Z
 permalink: updates/2011-01-25_the_new_hot_logo
 Person: Harry Wood
 Working Group: []
-Projects: []
+Project: []
 created: 1295952461
 ---
 

--- a/_posts/2011-01-26-a-big-thank-you-to-a-few-of-our-supporters.md
+++ b/_posts/2011-01-26-a-big-thank-you-to-a-few-of-our-supporters.md
@@ -4,7 +4,7 @@ date: 2011-01-26 23:54:33 Z
 permalink: updates/2011-01-26_a_big_thank_you_to_a_few_of_our_supporters
 Person: robert
 Working Group: []
-Projects: []
+Project: []
 created: 1296086073
 ---
 

--- a/_posts/2011-02-09-please-join-hot-conference-call-february-16-12pm-est.md
+++ b/_posts/2011-02-09-please-join-hot-conference-call-february-16-12pm-est.md
@@ -4,7 +4,7 @@ date: 2011-02-09 02:07:34 Z
 permalink: updates/2011-02-09_please_join!_hot_conference_call_february_16_12pm_est
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1297217254
 ---
 

--- a/_posts/2011-02-17-tufts-crisis-mapping-class.md
+++ b/_posts/2011-02-17-tufts-crisis-mapping-class.md
@@ -4,7 +4,7 @@ date: 2011-02-17 23:25:12 Z
 permalink: updates/2011-02-17_tufts_crisis_mapping_class
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1297985112
 ---
 

--- a/_posts/2011-03-11-an-midday-hour-of-mapping-on-logbase-in-port-au-prince.md
+++ b/_posts/2011-03-11-an-midday-hour-of-mapping-on-logbase-in-port-au-prince.md
@@ -4,7 +4,7 @@ date: 2011-03-11 05:40:54 Z
 permalink: updates/2011-03-11_an_midday_hour_of_mapping_on_logbase_in_port_au_prince
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/5515425818_92a2363b57.jpg
 created: 1299822054
 ---

--- a/_posts/2011-03-15-haiti-osm-mapping-for-japan-and-libya.md
+++ b/_posts/2011-03-15-haiti-osm-mapping-for-japan-and-libya.md
@@ -4,7 +4,7 @@ date: 2011-03-15 05:56:59 Z
 permalink: updates/2011-03-15_haiti_osm_mapping_for_japan_and_libya
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/5527736750_1ca7155c84.jpg
 created: 1300168619
 ---

--- a/_posts/2011-03-21-japan-earthquake-and-tsunami.md
+++ b/_posts/2011-03-21-japan-earthquake-and-tsunami.md
@@ -4,7 +4,7 @@ date: 2011-03-21 09:59:17 Z
 permalink: updates/2011-03-21_japan_earthquake_and_tsunami
 Person: Harry Wood
 Working Group: []
-Projects: []
+Project: []
 created: 1300701557
 ---
 

--- a/_posts/2011-05-17-continuing-hot-activation-for-the-ivory-coast.md
+++ b/_posts/2011-05-17-continuing-hot-activation-for-the-ivory-coast.md
@@ -4,7 +4,7 @@ date: 2011-05-17 10:38:19 Z
 permalink: updates/2011-05-17_continuing_hot_activation_for_the_ivory_coast
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1305628699
 ---
 

--- a/_posts/2011-06-16-bevlkerungsschutz-und-katastrophenhilfe.md
+++ b/_posts/2011-06-16-bevlkerungsschutz-und-katastrophenhilfe.md
@@ -4,7 +4,7 @@ date: 2011-06-16 18:01:23 Z
 permalink: updates/2011-06-16_bevölkerungsschutz_und_katastrophenhilfe
 Person: Harry Wood
 Working Group: []
-Projects: []
+Project: []
 created: 1308247283
 ---
 

--- a/_posts/2011-07-03-hot-in-indonesia.md
+++ b/_posts/2011-07-03-hot-in-indonesia.md
@@ -5,7 +5,7 @@ permalink: updates/2011-07-03_hot_in_indonesia
 Person: Kate Chapman
 Working Group:
 - Security
-Projects: []
+Project: []
 created: 1309714976
 ---
 

--- a/_posts/2011-07-05-hot-in-sumbawa-island-indonesia.md
+++ b/_posts/2011-07-05-hot-in-sumbawa-island-indonesia.md
@@ -4,7 +4,7 @@ date: 2011-07-05 22:11:38 Z
 permalink: updates/2011-07-05_hot_in_sumbawa_island_indonesia
 Person: Emir Hartato
 Working Group: []
-Projects: []
+Project: []
 created: 1309903898
 ---
 

--- a/_posts/2011-07-10-hot-in-lombok-indonesia.md
+++ b/_posts/2011-07-10-hot-in-lombok-indonesia.md
@@ -4,7 +4,7 @@ date: 2011-07-10 22:36:35 Z
 permalink: updates/2011-07-10_hot_in_lombok_indonesia
 Person: Emir Hartato
 Working Group: []
-Projects: []
+Project: []
 created: 1310337395
 ---
 

--- a/_posts/2011-07-11-hot-in-sumba-island-indonesia.md
+++ b/_posts/2011-07-11-hot-in-sumba-island-indonesia.md
@@ -4,7 +4,7 @@ date: 2011-07-11 20:40:50 Z
 permalink: updates/2011-07-11_hot_in_sumba_island_indonesia
 Person: Emir Hartato
 Working Group: []
-Projects: []
+Project: []
 created: 1310416850
 ---
 

--- a/_posts/2011-07-17-keren-osm-bantaeng-and-kupang-indonesia.md
+++ b/_posts/2011-07-17-keren-osm-bantaeng-and-kupang-indonesia.md
@@ -4,7 +4,7 @@ date: 2011-07-17 12:17:47 Z
 permalink: updates/2011-07-17_keren_osm_(bantaeng_and_kupang_indonesia)
 Person: Jeff Haack
 Working Group: []
-Projects: []
+Project: []
 created: 1310905067
 ---
 

--- a/_posts/2011-07-18-schuyler-erles-presentation-at-state-of-the-map-eu.md
+++ b/_posts/2011-07-18-schuyler-erles-presentation-at-state-of-the-map-eu.md
@@ -4,7 +4,7 @@ date: 2011-07-18 18:46:26 Z
 permalink: updates/2011-07-18_schuyler_erle's_presentation_at_state_of_the_map_eu
 Person: Harry Wood
 Working Group: []
-Projects: []
+Project: []
 created: 1311014786
 ---
 

--- a/_posts/2011-07-31-end-of-an-era-or-at-least-internship.md
+++ b/_posts/2011-07-31-end-of-an-era-or-at-least-internship.md
@@ -4,7 +4,7 @@ date: 2011-07-31 17:47:34 Z
 permalink: updates/2011-07-31_end_of_an_era_or_at_least_internship
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1312134454
 ---
 

--- a/_posts/2011-08-19-activation-in-somalia.md
+++ b/_posts/2011-08-19-activation-in-somalia.md
@@ -4,7 +4,7 @@ date: 2011-08-19 23:01:58 Z
 permalink: updates/2011-08-19_activation_in_somalia
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1313794918
 ---
 

--- a/_posts/2011-09-11-meeting-face-to-face-at-sotm-denver.md
+++ b/_posts/2011-09-11-meeting-face-to-face-at-sotm-denver.md
@@ -5,7 +5,7 @@ permalink: updates/2011-09-11_meeting_face-to-face_at_sotm_denver
 Person: Harry Wood
 Working Group:
 - Training
-Projects: []
+Project: []
 created: 1315779179
 ---
 

--- a/_posts/2011-09-20-hot-tasks-get-your-hot-tasks.md
+++ b/_posts/2011-09-20-hot-tasks-get-your-hot-tasks.md
@@ -6,7 +6,7 @@ Summary Text: A couple weeks ago Patrick Meier wrote about HOT's new tool for ta
   the OpenStreetMap Tasking Manager.  Now it has finally moved to its permanent home:tasks.hotosm.org
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - Tasking Manager
 created: 1316528732
 ---

--- a/_posts/2011-09-28-7-indonesian-students-goes-to-denver-for-sotm-and-foss4g.md
+++ b/_posts/2011-09-28-7-indonesian-students-goes-to-denver-for-sotm-and-foss4g.md
@@ -4,7 +4,7 @@ date: 2011-09-28 15:00:15 Z
 permalink: updates/2011-09-28_7_indonesian_students_goes_to_denver_for_sotm_and_foss4g!
 Person: Emir Hartato
 Working Group: []
-Projects: []
+Project: []
 created: 1317222015
 ---
 

--- a/_posts/2011-11-11-the-amazing-osm-community-and-the-tasking-server-maps-swaziland.md
+++ b/_posts/2011-11-11-the-amazing-osm-community-and-the-tasking-server-maps-swaziland.md
@@ -4,7 +4,7 @@ date: 2011-11-11 05:10:12 Z
 permalink: updates/2011-11-11_the_amazing_osm_community_and_the_tasking_server_maps_swaziland
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1320988212
 ---
 

--- a/_posts/2011-11-27-meetings-conferences-and-coordination-in-geneva.md
+++ b/_posts/2011-11-27-meetings-conferences-and-coordination-in-geneva.md
@@ -5,7 +5,7 @@ permalink: updates/2011-11-27_meetings_conferences_and_coordination_in_geneva
 Person: Kate Chapman
 Working Group:
 - Community
-Projects: []
+Project: []
 created: 1322433785
 ---
 

--- a/_posts/2011-12-02-poverty-mapping-with-an-openstreetmap-base-in-sumbawa.md
+++ b/_posts/2011-12-02-poverty-mapping-with-an-openstreetmap-base-in-sumbawa.md
@@ -4,7 +4,7 @@ date: 2011-12-02 12:18:32 Z
 permalink: updates/2011-12-02_poverty_mapping_with_an_openstreetmap_base_in_sumbawa
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1322828312
 ---
 

--- a/_posts/2011-12-08-openstreetmap-and-quantum-gis-training-in-bali.md
+++ b/_posts/2011-12-08-openstreetmap-and-quantum-gis-training-in-bali.md
@@ -4,7 +4,7 @@ date: 2011-12-08 15:17:46 Z
 permalink: updates/2011-12-08_openstreetmap_and_quantum_gis_training_in_bali
 Person: Emir Hartato
 Working Group: []
-Projects: []
+Project: []
 created: 1323357466
 ---
 

--- a/_posts/2011-12-18-cooperation-between-hot-and-digitalglobe-in-turkey.md
+++ b/_posts/2011-12-18-cooperation-between-hot-and-digitalglobe-in-turkey.md
@@ -4,7 +4,7 @@ date: 2011-12-18 17:36:23 Z
 permalink: updates/2011-12-18_cooperation_between_hot_and_digitalglobe_in_turkey
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1324229783
 ---
 

--- a/_posts/2011-12-20-activation-to-map-libyan-health-facilities.md
+++ b/_posts/2011-12-20-activation-to-map-libyan-health-facilities.md
@@ -4,7 +4,7 @@ date: 2011-12-20 00:34:23 Z
 permalink: updates/2011-12-20_activation_to_map_libyan_health_facilities
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1324341263
 ---
 

--- a/_posts/2011-12-21-schuyler-erle-and-john-crowley-join-the-board.md
+++ b/_posts/2011-12-21-schuyler-erle-and-john-crowley-join-the-board.md
@@ -4,7 +4,7 @@ date: 2011-12-21 10:38:32 Z
 permalink: updates/2011-12-21_schuyler_erle_and_john_crowley_join_the_board
 Person: Harry Wood
 Working Group: []
-Projects: []
+Project: []
 created: 1324463912
 ---
 

--- a/_posts/2012-01-07-christmas-donation-from-nestoria.md
+++ b/_posts/2012-01-07-christmas-donation-from-nestoria.md
@@ -4,7 +4,7 @@ date: 2012-01-07 04:33:15 Z
 permalink: updates/2012-01-07_christmas_donation_from_nestoria
 Person: Harry Wood
 Working Group: []
-Projects: []
+Project: []
 created: 1325910795
 ---
 

--- a/_posts/2012-01-10-hot-collaboration-with-gis-corps.md
+++ b/_posts/2012-01-10-hot-collaboration-with-gis-corps.md
@@ -4,7 +4,7 @@ date: 2012-01-10 05:48:39 Z
 permalink: updates/2012-01-10_hot_collaboration_with_gis_corps!
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1326174519
 ---
 

--- a/_posts/2012-01-12-a-return-to-haiti-two-years-on.md
+++ b/_posts/2012-01-12-a-return-to-haiti-two-years-on.md
@@ -4,7 +4,7 @@ date: 2012-01-12 00:00:00 Z
 permalink: updates/2012-01-12_a_return_to_haiti_two_years_on
 Person: Nicolas Chavent
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 created: 1326326400
 ---

--- a/_posts/2012-01-25-hot-at-haiti-communitere.md
+++ b/_posts/2012-01-25-hot-at-haiti-communitere.md
@@ -12,7 +12,7 @@ Summary Text: Since returning to Haiti in preparation of launching the Saint Mar
   aerial.jpg" />
 Person: Nicolas Chavent
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/HC+aerial.jpg
 created: 1327472219

--- a/_posts/2012-01-25-hot-mapping-for-flash-flood-affected-areas-in-northern-mindanao-philippines.md
+++ b/_posts/2012-01-25-hot-mapping-for-flash-flood-affected-areas-in-northern-mindanao-philippines.md
@@ -10,7 +10,7 @@ Summary Text: '<p>Northern Mindanao(specifically <a href="http://osm.org/go/4sXd
   are served inside and outside 62 evacuation centers</a> '
 Person: Maning Sambale
 Working Group: []
-Projects: []
+Project: []
 created: 1327474632
 ---
 

--- a/_posts/2012-01-27-a-week-in-between-pap-and-saint-marc.md
+++ b/_posts/2012-01-27-a-week-in-between-pap-and-saint-marc.md
@@ -4,7 +4,7 @@ date: 2012-01-27 02:28:41 Z
 permalink: updates/2012-01-27_a_week_in_between_pap_and_saint_marc
 Person: Brian Wolford
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/DSC00057_0.jpg
 created: 1327631321

--- a/_posts/2012-01-28-setting-up-in-saint-marc-haiti.md
+++ b/_posts/2012-01-28-setting-up-in-saint-marc-haiti.md
@@ -9,7 +9,7 @@ Summary Text: Having had a brief moment to get out footing in Saint Marc, we wer
   />
 Person: Brian Wolford
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/DSC00313_0.jpg
 created: 1327776499

--- a/_posts/2012-01-31-back-back-back-to-sumbawa.md
+++ b/_posts/2012-01-31-back-back-back-to-sumbawa.md
@@ -10,7 +10,7 @@ Summary Text: <p>This week Vasanthi, Emir and I returned to Bima and Dompu. It i
   and Dompu were no different.<p><img src="http://hot.openstreetmap.org/sites/default/files/emir_teaching.png"/>
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/emir_teaching.png
 created: 1327982468
 ---

--- a/_posts/2012-01-31-wrapping-up-the-libyan-health-facility-activation.md
+++ b/_posts/2012-01-31-wrapping-up-the-libyan-health-facility-activation.md
@@ -8,7 +8,7 @@ Summary Text: <p>On January 14, we formally closed <a href="http://hot.openstree
   at the Tunis WMC office was incredibly active in the entire process.
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1328032204
 ---
 

--- a/_posts/2012-02-02-mapping-in-saint-marc-get-on-board-or-get-out-of-the-way.md
+++ b/_posts/2012-02-02-mapping-in-saint-marc-get-on-board-or-get-out-of-the-way.md
@@ -11,7 +11,7 @@ Summary Text: Hey there, Hi there, Ho there,Checking in from beautiful coastal S
   activities and maybe participates in a training them selves.<img src="http://hot.openstreetmap.org/sites/default/files/DSC00342.jpg"/>
 Person: Brian Wolford
 Working Group: []
-Projects: []
+Project: []
 created: 1328152207
 ---
 

--- a/_posts/2012-02-06-mapping-in-afghanistan-with-jalalagood.md
+++ b/_posts/2012-02-06-mapping-in-afghanistan-with-jalalagood.md
@@ -8,7 +8,7 @@ Summary Text: 'Below is a video about OpenStreetMap in Afghanistan, HOT member H
   where a reliable fast Internet connection would cost $1000 a month. '
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1328555918
 ---
 

--- a/_posts/2012-02-20-hand-over-in-saint-marc-haiti.md
+++ b/_posts/2012-02-20-hand-over-in-saint-marc-haiti.md
@@ -5,7 +5,7 @@ permalink: updates/2012-02-20_hand_over_in_saint-marc_haiti
 Person: Séverin Ménard
 Working Group:
 - Training
-Projects:
+Project:
 - 'Haiti '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/P1160118_800px.JPG
 created: 1329748511

--- a/_posts/2012-02-22-foreign-affairs-and-international-trade-canada-department-ottawa.md
+++ b/_posts/2012-02-22-foreign-affairs-and-international-trade-canada-department-ottawa.md
@@ -12,7 +12,7 @@ Summary Text: "<p>Foreign Affairs and International Trade Canada department (DFA
   Foundation and World Bank representatives."
 Person: Pierre Béland
 Working Group: []
-Projects: []
+Project: []
 created: 1329924292
 ---
 

--- a/_posts/2012-02-29-4th-largest-country-4th-largest-city-best-community-mapped-for-preparedness.md
+++ b/_posts/2012-02-29-4th-largest-country-4th-largest-city-best-community-mapped-for-preparedness.md
@@ -14,7 +14,7 @@ Summary Text: Rapid growth and low elevation makes flooding in Jakarta problemat
   such data, by utilizing OpenStreetMap.
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/osm_id_sticker.png
 created: 1330504391

--- a/_posts/2012-03-10-night-of-the-living-maps-in-saint-marc-02-07-2012.md
+++ b/_posts/2012-03-10-night-of-the-living-maps-in-saint-marc-02-07-2012.md
@@ -4,7 +4,7 @@ date: 2012-03-10 17:38:41 Z
 permalink: updates/2012-03-10_night_of_the_living_maps_in_saint-marc_02/07/2012
 Person: Séverin Ménard
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 created: 1331401121
 ---

--- a/_posts/2012-03-12-creating-sustainable-community-mapping-projects-workshop.md
+++ b/_posts/2012-03-12-creating-sustainable-community-mapping-projects-workshop.md
@@ -4,7 +4,7 @@ date: 2012-03-12 05:00:39 Z
 permalink: updates/2012-03-12_creating_sustainable_community_mapping_projects_workshop
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 created: 1331528439
 ---

--- a/_posts/2012-03-20-the-world-bank-and-open-maps-for-development-im-excited.md
+++ b/_posts/2012-03-20-the-world-bank-and-open-maps-for-development-im-excited.md
@@ -4,7 +4,7 @@ date: 2012-03-20 04:48:49 Z
 permalink: updates/2012-03-20_the_world_bank_and_open_maps_for_development_i'm_excited
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/world_bank_map_cake.jpg
 created: 1332218929
 ---

--- a/_posts/2012-03-30-finishing-up-in-indonesia-for-the-moment.md
+++ b/_posts/2012-03-30-finishing-up-in-indonesia-for-the-moment.md
@@ -10,7 +10,7 @@ Summary Text: Tomorrow marks the end of HOT's pilot to evaluate the use of OpenS
   expand.<h2>Accomplishments</h2>
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/mapping_bima.jpg
 created: 1333085855

--- a/_posts/2012-04-24-coming-to-a-close-in-saint-marc.md
+++ b/_posts/2012-04-24-coming-to-a-close-in-saint-marc.md
@@ -13,7 +13,7 @@ Summary Text: Hey kiddoes!Brian checking in from Saint-Marc. We are in the final
   finished, congrats to them.
 Person: Brian Wolford
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2012-01-08.png
 created: 1335233135

--- a/_posts/2012-04-26-washington-dc-is-nothing-but-hot-next-week.md
+++ b/_posts/2012-04-26-washington-dc-is-nothing-but-hot-next-week.md
@@ -13,7 +13,7 @@ Summary Text: Next week the Board of Directors of the Humanitarian OpenStreetMap
   GeoDC - Crisis Mapping Focused May Meet-up</a></h3>
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1335445988
 ---
 

--- a/_posts/2012-04-29-graduation-for-stm020.md
+++ b/_posts/2012-04-29-graduation-for-stm020.md
@@ -13,7 +13,7 @@ Summary Text: On the evening of April 24th there was a graduation for the young 
   desire to see a program like this happen in the next location.
 Person: Brian Wolford
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG013_0.jpg
 created: 1335730152

--- a/_posts/2012-05-10-back-the-first-haitian-creole-openstreetmap-book.md
+++ b/_posts/2012-05-10-back-the-first-haitian-creole-openstreetmap-book.md
@@ -12,7 +12,7 @@ Summary Text: When the January 2010 Earthquake happened in Haiti the OpenStreetM
   width="480px"></iframe>
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 created: 1336656800
 ---

--- a/_posts/2012-05-14-update-from-hots-strategic-planning-meeting.md
+++ b/_posts/2012-05-14-update-from-hots-strategic-planning-meeting.md
@@ -9,7 +9,7 @@ Summary Text: Two weeks ago through a micro-grant from the <a href="http://wilso
   to grow in the next 3-5 years.
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/hot_board.jpg
 created: 1337013541
 ---

--- a/_posts/2012-05-18-first-use-of-new-imagery-agreement-join-hot-to-trace-refugee-camps-in-kenya-and-ethiopia.md
+++ b/_posts/2012-05-18-first-use-of-new-imagery-agreement-join-hot-to-trace-refugee-camps-in-kenya-and-ethiopia.md
@@ -5,7 +5,7 @@ date: 2012-05-18 14:48:54 Z
 permalink: updates/2012-05-18_first_use_of_new_imagery__agreement_join_hot_to_trace_refugee_camps_in_kenya_and
 Person: John Crowley
 Working Group: []
-Projects: []
+Project: []
 created: 1337352534
 ---
 

--- a/_posts/2012-05-25-openstreetmap-at-the-harvard-humanitarian-initiative-disaster-simulation.md
+++ b/_posts/2012-05-25-openstreetmap-at-the-harvard-humanitarian-initiative-disaster-simulation.md
@@ -10,7 +10,7 @@ Summary Text: Last year I spent a bitterly cold day in a forest in Massachusetts
   Spanring, Kate Chapman, and myself helped to bring some maps together for the sim.
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1337909310
 ---
 

--- a/_posts/2012-06-22-finishing-off-the-refugee-camp-mapping.md
+++ b/_posts/2012-06-22-finishing-off-the-refugee-camp-mapping.md
@@ -12,7 +12,7 @@ Summary Text: Last month <a href="http://hot.openstreetmap.org/updates/2012-05-1
   to trace from, our community could map the refugee camps in a short space of time.
 Person: Harry Wood
 Working Group: []
-Projects:
+Project:
 - Somalia
 created: 1340406241
 ---

--- a/_posts/2012-06-24-hots-first-days-in-senegal.md
+++ b/_posts/2012-06-24-hots-first-days-in-senegal.md
@@ -7,7 +7,7 @@ Summary Text: The first days in Sénégal flew by for the three of us engaged in
   Stephane Goldstein and Will Skora.
 Person: Will Skora
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/DSCN0003.JPG
 created: 1340564324
 ---

--- a/_posts/2012-06-24-return-to-the-training-in-saint-marc-haiti-mixing-generic-and-specific-teaching-aid-to-build-strong-.md
+++ b/_posts/2012-06-24-return-to-the-training-in-saint-marc-haiti-mixing-generic-and-specific-teaching-aid-to-build-strong-.md
@@ -12,7 +12,7 @@ Summary Text: 'Our previous posts about the Saint-Marc, Haiti project did not fo
   the three months of the program. '
 Person: Séverin Ménard
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/STM020_training_Nicolas.jpg
 created: 1340580918

--- a/_posts/2012-07-13-out-and-about-in-yogyakarta-indonesia-an-osm-workshop-sponsored-by-the-world-bank.md
+++ b/_posts/2012-07-13-out-and-about-in-yogyakarta-indonesia-an-osm-workshop-sponsored-by-the-world-bank.md
@@ -13,7 +13,7 @@ Summary Text: My name is Katrina and I am a new addition to the HOT team in Indo
   quarters.  <em> The Participants </em>
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/1_0.jpg
 created: 1342169398

--- a/_posts/2012-07-20-understanding-risk-forum-mapping-global-risk-july-2-6-2012.md
+++ b/_posts/2012-07-20-understanding-risk-forum-mapping-global-risk-july-2-6-2012.md
@@ -4,7 +4,7 @@ date: 2012-07-20 18:29:42 Z
 permalink: updates/2012-07-20_understanding_risk_forum_mapping_global_risk_july_2-6_2012
 Person: Pierre Béland
 Working Group: []
-Projects: []
+Project: []
 created: 1342808982
 ---
 

--- a/_posts/2012-07-31-indonesian-project-report-get-it-while-its-hot.md
+++ b/_posts/2012-07-31-indonesian-project-report-get-it-while-its-hot.md
@@ -10,7 +10,7 @@ Summary Text: 'Kate Chapman, with assistance from Emir Hartato, her Indonesian t
   developed.'
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/cover_image.jpg
 created: 1343711996

--- a/_posts/2012-07-31-setting-up-the-osm-ecosystem-in-senegal-1-reaching-out-to-gis-projects.md
+++ b/_posts/2012-07-31-setting-up-the-osm-ecosystem-in-senegal-1-reaching-out-to-gis-projects.md
@@ -4,7 +4,7 @@ date: 2012-07-31 13:18:20 Z
 permalink: updates/2012-07-31_setting_up_the_osm_ecosystem_in_senegal_1_reaching_out_to_gis_projects
 Person: Nicolas Chavent
 Working Group: []
-Projects:
+Project:
 - Senegal
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/image001_0.jpg
 created: 1343740700

--- a/_posts/2012-08-06-setting-up-the-osm-ecosystem-in-senegal-2-reaching-out-to-the-senegalese-tech-communities.md
+++ b/_posts/2012-08-06-setting-up-the-osm-ecosystem-in-senegal-2-reaching-out-to-the-senegalese-tech-communities.md
@@ -5,7 +5,7 @@ date: 2012-08-06 16:33:50 Z
 permalink: updates/2012-08-06_setting_up_the_osm_ecosystem_in_senegal_2_reaching_out_to_the_senegalese_tech_co
 Person: Will Skora
 Working Group: []
-Projects:
+Project:
 - Senegal
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/553835_463655630329527_1075723890_n.jpg
 created: 1344270830

--- a/_posts/2012-08-08-setting-up-the-osm-ecosystem-in-senegal-3-reaching-out-the-senegalese-geomatics-scene-senegalese-sdi.md
+++ b/_posts/2012-08-08-setting-up-the-osm-ecosystem-in-senegal-3-reaching-out-the-senegalese-geomatics-scene-senegalese-sdi.md
@@ -9,7 +9,7 @@ Summary Text: 'With the support of the ICT Directorate and the Agence Informatiq
   held a one day workshop around OSM at the ADIE office on June 7th. '
 Person: Nicolas Chavent
 Working Group: []
-Projects:
+Project:
 - Senegal
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/image004_0.jpg
 created: 1344446686

--- a/_posts/2012-08-11-setting-up-the-osm-ecosystem-in-senegal-4-reaching-out-to-the-academics.md
+++ b/_posts/2012-08-11-setting-up-the-osm-ecosystem-in-senegal-4-reaching-out-to-the-academics.md
@@ -4,7 +4,7 @@ date: 2012-08-11 11:21:52 Z
 permalink: updates/2012-08-11_setting_up_the_osm_ecosystem_in_senegal_4_reaching_out_to_the_academics
 Person: Stephane Goldstein
 Working Group: []
-Projects: []
+Project: []
 created: 1344684112
 ---
 

--- a/_posts/2012-08-14-setting-up-the-osm-ecosystem-in-senegal-5-building-a-local-osm-groups-in-louga.md
+++ b/_posts/2012-08-14-setting-up-the-osm-ecosystem-in-senegal-5-building-a-local-osm-groups-in-louga.md
@@ -5,7 +5,7 @@ date: 2012-08-14 13:34:28 Z
 permalink: updates/2012-08-14_setting_up_the_osm_ecosystem_in_senegal_5_building_a_local_osm_groups_in_louga
 Person: Stephane Goldstein
 Working Group: []
-Projects: []
+Project: []
 created: 1344951268
 ---
 

--- a/_posts/2012-08-16-setting-up-the-osm-ecosystem-in-senegal-6-building-the-humanitarian-component.md
+++ b/_posts/2012-08-16-setting-up-the-osm-ecosystem-in-senegal-6-building-the-humanitarian-component.md
@@ -10,7 +10,7 @@ Summary Text: 'It’s finally time to mention the mapping party HOT and <a href=
   and HOT. '
 Person: Nicolas Chavent
 Working Group: []
-Projects:
+Project:
 - Senegal
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/image008_0.jpg
 created: 1345128771

--- a/_posts/2012-08-20-preventative-mapping-in-uganda-with-the-red-cross.md
+++ b/_posts/2012-08-20-preventative-mapping-in-uganda-with-the-red-cross.md
@@ -13,7 +13,7 @@ Summary Text: 'HOT has teamed up with the American and Ugandan Red Cross to virt
   or accidents.    '
 Person: Katrina E.
 Working Group: []
-Projects: []
+Project: []
 created: 1345482033
 ---
 

--- a/_posts/2012-08-23-tropical-storm-isaac-getting-to-haiti.md
+++ b/_posts/2012-08-23-tropical-storm-isaac-getting-to-haiti.md
@@ -10,7 +10,7 @@ Summary Text: 'Came accross this serious hurricane warning today from <a href="h
   and have carried out many OSM activities and participated to HOT programs there. '
 Person: Séverin Ménard
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 created: 1345740679
 ---

--- a/_posts/2012-08-28-the-osm-project-senegal-joining-tech-camp-dakar-30-31-august-2012.md
+++ b/_posts/2012-08-28-the-osm-project-senegal-joining-tech-camp-dakar-30-31-august-2012.md
@@ -13,7 +13,7 @@ Summary Text: I am starting a second short trip (28-August – 2-September) to D
   for their continued support. All made this second trip to Senegal possible.
 Person: Nicolas Chavent
 Working Group: []
-Projects:
+Project:
 - Senegal
 created: 1346196446
 ---

--- a/_posts/2012-09-11-selamat-new-hot-trainers.md
+++ b/_posts/2012-09-11-selamat-new-hot-trainers.md
@@ -5,7 +5,7 @@ permalink: updates/2012-09-11_selamat_new_hot_trainers
 Summary Text: ''
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Selection_026_1.png
 created: 1347352400

--- a/_posts/2012-09-24-from-remote-tracing-to-field-mapping-in-padang.md
+++ b/_posts/2012-09-24-from-remote-tracing-to-field-mapping-in-padang.md
@@ -4,7 +4,7 @@ date: 2012-09-24 06:57:34 Z
 permalink: updates/2012-09-24_from_remote_tracing_to_field_mapping_in_padang
 Person: Joseph Reeves
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 created: 1348469854
 ---

--- a/_posts/2012-09-30-hot-at-picnic.md
+++ b/_posts/2012-09-30-hot-at-picnic.md
@@ -4,7 +4,7 @@ date: 2012-09-30 16:01:43 Z
 permalink: updates/2012-09-30_hot_at_picnic
 Person: Harry Wood
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/HOT-PICNIC-presentation.jpg
 created: 1349020903
 ---

--- a/_posts/2012-10-05-become-a-tutor-of-the-eurosha-volunteers.md
+++ b/_posts/2012-10-05-become-a-tutor-of-the-eurosha-volunteers.md
@@ -14,7 +14,7 @@ Summary Text: Nicolas and I have been training the 25 Eurosha volunteers who wil
   1024x768.JPG]
 Person: Séverin Ménard
 Working Group: []
-Projects:
+Project:
 - EUROSHA
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/P1200042+1024x768.JPG
 created: 1349395980

--- a/_posts/2012-10-22-update-from-the-red-cross-on-gulu-and-lira.md
+++ b/_posts/2012-10-22-update-from-the-red-cross-on-gulu-and-lira.md
@@ -13,7 +13,7 @@ Summary Text: "<p><i>An update and thank you from Robert Banick at the American 
   to see their contributions go right into the map. [inline:Gulu Fire Risk.png]"
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2012-09-03+11.47.37+HDR_0.jpg
 created: 1350922909
 ---

--- a/_posts/2012-10-24-asian-ministerial-conference-on-disaster-risk-reduction-amcdrr-2012.md
+++ b/_posts/2012-10-24-asian-ministerial-conference-on-disaster-risk-reduction-amcdrr-2012.md
@@ -5,7 +5,7 @@ permalink: updates/2012-10-24_asian_ministerial_conference_on_disaster_risk_redu
 Summary Text: ''
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/20121022_101027.jpg
 created: 1351055706

--- a/_posts/2012-10-25-hot-and-wikimedia-indonesia-join-forces.md
+++ b/_posts/2012-10-25-hot-and-wikimedia-indonesia-join-forces.md
@@ -14,7 +14,7 @@ Summary Text: 'We met at the National Library of Indonesia-- partly for its spac
   and link these pages to OSM, and other maps.  '
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Selection_115.png
 created: 1351142550

--- a/_posts/2012-10-29-beginning-workshop-debrief.md
+++ b/_posts/2012-10-29-beginning-workshop-debrief.md
@@ -10,7 +10,7 @@ Summary Text: Last week we finished our Beginning OSM workshops for BPBD staff, 
   what our team had to say about the beginning workshops
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/image.jpg
 created: 1351508403

--- a/_posts/2012-11-01-two-weeks-of-field-work-within-the-eurosha-chad-project.md
+++ b/_posts/2012-11-01-two-weeks-of-field-work-within-the-eurosha-chad-project.md
@@ -14,7 +14,7 @@ Summary Text: 'Last night of hard work in the meeting room of the UNHCR in Gore 
   stronger effect when experienced during a deployment. '
 Person: Nicolas Chavent
 Working Group: []
-Projects:
+Project:
 - EUROSHA
 created: 1351737875
 ---

--- a/_posts/2012-11-03-digital-humanitarian-network-simulation-at-iccm-washington-dc.md
+++ b/_posts/2012-11-03-digital-humanitarian-network-simulation-at-iccm-washington-dc.md
@@ -4,7 +4,7 @@ date: 2012-11-03 08:35:07 Z
 permalink: updates/2012-11-03_digital_humanitarian_network_simulation_at_iccm_washington_dc
 Person: Séverin Ménard
 Working Group: []
-Projects: []
+Project: []
 created: 1351931707
 ---
 

--- a/_posts/2012-11-07-faces-of-hot-meet-dewi-indonesian-osm-trainer.md
+++ b/_posts/2012-11-07-faces-of-hot-meet-dewi-indonesian-osm-trainer.md
@@ -9,7 +9,7 @@ Summary Text: 'Since August 2012, the HOT team has included eight Indonesian tra
   Sulistioningrum </strong> (say that ten times fast...).  '
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/dewi2_0.jpg
 created: 1352279989

--- a/_posts/2012-11-22-faces-of-hot-volunteer-joseph-reeves.md
+++ b/_posts/2012-11-22-faces-of-hot-volunteer-joseph-reeves.md
@@ -9,7 +9,7 @@ Summary Text: We have been fortunate to get a few volunteers for this Indonesian
   project.  He has helped lead workshops on the basics of OpenstreetMap.  [inline:jose.jpg]
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/jose.jpg
 created: 1353565235

--- a/_posts/2012-12-05-osm-flossmanuals-in-kreyl.md
+++ b/_posts/2012-12-05-osm-flossmanuals-in-kreyl.md
@@ -13,7 +13,7 @@ Summary Text: 'This week in Port-au-Prince is happening a booksprint to write a 
   on paper format). '
 Person: Anne Goldenberg
 Working Group: []
-Projects:
+Project:
 - OSM FlossManuals in Kreyòl (Creole)
 created: 1354725060
 ---

--- a/_posts/2012-12-07-intermediate-trainings-begin.md
+++ b/_posts/2012-12-07-intermediate-trainings-begin.md
@@ -11,7 +11,7 @@ Summary Text: "Last week, we started intermediate training for the six disaster 
   the Wiki 04.  Creating XML and JOSM presets05.  Private Data Store"
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/inter.jpg
 created: 1354855959

--- a/_posts/2012-12-12-hot-activation-south-and-north-kivu-democratic-republic-of-congo.md
+++ b/_posts/2012-12-12-hot-activation-south-and-north-kivu-democratic-republic-of-congo.md
@@ -4,7 +4,7 @@ date: 2012-12-12 20:11:34 Z
 permalink: updates/2012-12-12_hot_activation_south_and_north_kivu_democratic_republic_of_congo
 Person: Pierre Béland
 Working Group: []
-Projects: []
+Project: []
 created: 1355343094
 ---
 

--- a/_posts/2012-12-13-hot-activation-sud-et-nord-kivu-rpublique-dmocratique-du-congo.md
+++ b/_posts/2012-12-13-hot-activation-sud-et-nord-kivu-rpublique-dmocratique-du-congo.md
@@ -4,7 +4,7 @@ date: 2012-12-13 19:26:24 Z
 permalink: updates/2012-12-13_hot_activation_sud_et_nord_kivu_république_démocratique_du_congo
 Person: Pierre Béland
 Working Group: []
-Projects: []
+Project: []
 created: 1355426784
 ---
 

--- a/_posts/2012-12-17-hot-goes-cartographic-with-tilemill.md
+++ b/_posts/2012-12-17-hot-goes-cartographic-with-tilemill.md
@@ -4,7 +4,7 @@ date: 2012-12-17 09:01:06 Z
 permalink: updates/2012-12-17_hot_goes_cartographic_with_tilemill
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Selection_296.png
 created: 1355734866

--- a/_posts/2012-12-18-faces-of-hot-mikel-maron-hot-president-and-co-founder.md
+++ b/_posts/2012-12-18-faces-of-hot-mikel-maron-hot-president-and-co-founder.md
@@ -10,7 +10,7 @@ Summary Text: 'As one of the co-founders of <strong>HOT</strong>, Mikel has year
   OpenStreetMap project and various aspects of the Humanitarian OpenstreetMap Team. '
 Person: Katrina E.
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Selection_294.png
 created: 1355802111
 ---

--- a/_posts/2013-01-02-2012-was-hot-cant-wait-for-2013.md
+++ b/_posts/2013-01-02-2012-was-hot-cant-wait-for-2013.md
@@ -12,7 +12,7 @@ Summary Text: Closing out 2012 HOT has been officially in existence for over two
   continued growth of the organization.
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1357137581
 ---
 

--- a/_posts/2013-01-03-public-private-partnership-to-map-west-nusa-tenggara.md
+++ b/_posts/2013-01-03-public-private-partnership-to-map-west-nusa-tenggara.md
@@ -4,7 +4,7 @@ date: 2013-01-03 05:18:00 Z
 permalink: updates/2013-01-03_public/private_partnership_to_map_west_nusa_tenggara
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/ntb_mapping.png
 created: 1357190280

--- a/_posts/2013-01-04-mapping-selayar-island-with-help-from-mapbox-and-geoeye.md
+++ b/_posts/2013-01-04-mapping-selayar-island-with-help-from-mapbox-and-geoeye.md
@@ -4,7 +4,7 @@ date: 2013-01-04 16:16:02 Z
 permalink: updates/2013-01-04_mapping_selayar_island_with_help_from_mapbox_and_geoeye
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/selayar.jpg
 created: 1357316162

--- a/_posts/2013-01-09-back-to-senegal-further-creating-a-mapping-community.md
+++ b/_posts/2013-01-09-back-to-senegal-further-creating-a-mapping-community.md
@@ -9,7 +9,7 @@ Summary Text: 'Augustin and I conducted HOT’s third deployment HOT to Senegal 
   partnership with OpenStreetMap France.'
 Person: Nicolas Chavent
 Working Group: []
-Projects:
+Project:
 - Senegal
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/001.JPG
 created: 1357731982

--- a/_posts/2013-01-15-animating-the-osm-senegal-community.md
+++ b/_posts/2013-01-15-animating-the-osm-senegal-community.md
@@ -12,7 +12,7 @@ Summary Text: In Dakar, back from Saint-Louis where I have been mostly working a
   SN community the attendance of the <a href="http://barcampthies.org/"> Thies BarCamp</a>
   organized by the Senegalese OpenSource movement.
 Working Group: []
-Projects:
+Project:
 - Senegal
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/069_1.JPG
 created: 1358291567

--- a/_posts/2013-01-18-completion-of-intermediate-workshops.md
+++ b/_posts/2013-01-18-completion-of-intermediate-workshops.md
@@ -12,7 +12,7 @@ Summary Text: The six pilot workshops to the BNPB on intermediate OSM skills wer
   to higher ground.  Read more about the Jakarta Floods <a href=“http://www.thejakartapost.com/news/2013/01/17/jakarta-flood-death-toll-increases-five.html“>here</a>.)
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Selection_124.png
 created: 1358506382

--- a/_posts/2013-01-18-openstreetmap-usage-in-jakarta-flood-response.md
+++ b/_posts/2013-01-18-openstreetmap-usage-in-jakarta-flood-response.md
@@ -9,7 +9,7 @@ Summary Text: 'Days of rain in Jakarta and surrounding areas have caused massive
   27th for Indonesia''s capital city</a>. '
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/flooding.jpg
 created: 1358508761

--- a/_posts/2013-01-21-faces-of-hot-two-new-board-members-pierre-beland-and-joseph-reeves.md
+++ b/_posts/2013-01-21-faces-of-hot-two-new-board-members-pierre-beland-and-joseph-reeves.md
@@ -12,7 +12,7 @@ Summary Text: <p><b>Pierre Béland</b> and <b>Joseph Reeves</b> were voted onto 
   can read about that active project <a href="/updates/2012-12-12_hot_activation_south_and_north_kivu_democratic_republic_of_congo">here</a>.  <p>[inline:jose.jpg]
 Person: Katrina E.
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/jose_0.jpg
 created: 1358751605
 ---

--- a/_posts/2013-01-23-return-on-writing-the-manual-on-openstreetmap-kreyol-ayitien.md
+++ b/_posts/2013-01-23-return-on-writing-the-manual-on-openstreetmap-kreyol-ayitien.md
@@ -10,7 +10,7 @@ Summary Text: Début décembre, j'annonçais le début d'un libérathon qui visa
   donc un petit retour sur le déroulement du sprint.
 Person: Anne Goldenberg
 Working Group: []
-Projects:
+Project:
 - OSM FlossManuals in Kreyòl (Creole)
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Capture+du+2012-12-23+01:01:33_0.png
 created: 1358963833

--- a/_posts/2013-01-28-syria-activation.md
+++ b/_posts/2013-01-28-syria-activation.md
@@ -10,7 +10,7 @@ Summary Text: Following a request from UN OCHA and SNAP, HOT is activating a rem
   in this area.
 Person: Joseph Reeves
 Working Group: []
-Projects: []
+Project: []
 created: 1359375884
 ---
 

--- a/_posts/2013-01-31-the-openstreetmap_senegal-osm_sn-community-is-expanding-to-the-region-of-casamance-in-senegal.md
+++ b/_posts/2013-01-31-the-openstreetmap_senegal-osm_sn-community-is-expanding-to-the-region-of-casamance-in-senegal.md
@@ -4,7 +4,7 @@ title: The Openstreetmap_Senegal (OSM_SN) community is expanding to the region o
 date: 2013-01-31 00:41:37 Z
 permalink: updates/2013-01-31_the_openstreetmap_senegal_(osm_sn)_community_is_expanding_to_the_region_of_casam
 Working Group: []
-Projects:
+Project:
 - Senegal
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/image1.JPG
 created: 1359592897

--- a/_posts/2013-02-01-a-return-to-chad-three-months-after-the-set-up-of-the-eurosha-mapping-team.md
+++ b/_posts/2013-02-01-a-return-to-chad-three-months-after-the-set-up-of-the-eurosha-mapping-team.md
@@ -12,7 +12,7 @@ Summary Text: 'I just landed in <a href="http://en.wikipedia.org/wiki/N''Djamena
   project</a> '
 Person: Nicolas Chavent
 Working Group: []
-Projects:
+Project:
 - EUROSHA
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/262743_375600389201144_554436941_n_1.jpg
 created: 1359683312

--- a/_posts/2013-02-01-activation-pour-le-mali.md
+++ b/_posts/2013-02-01-activation-pour-le-mali.md
@@ -13,7 +13,7 @@ Summary Text: Cette activation fait suite aux discussions entre HOT et le Bureau
   de personnes sont déplacées à l'intérieur du Mali.</li>
 Person: Pierre Béland
 Working Group: []
-Projects: []
+Project: []
 created: 1359741029
 ---
 

--- a/_posts/2013-02-01-mali-activation.md
+++ b/_posts/2013-02-01-mali-activation.md
@@ -14,7 +14,7 @@ Summary Text: This Activation follows discussions between HOT and the United Nat
   refugees in neighbouring countries.</li>
 Person: Pierre Béland
 Working Group: []
-Projects: []
+Project: []
 created: 1359740943
 ---
 

--- a/_posts/2013-02-01-openir-meets-with-the-indonesian-team.md
+++ b/_posts/2013-02-01-openir-meets-with-the-indonesian-team.md
@@ -4,7 +4,7 @@ date: 2013-02-01 08:27:28 Z
 permalink: updates/2013-02-01_openir_meets_with_the_indonesian_team
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Selection_349.png
 created: 1359707248

--- a/_posts/2013-02-06-syria-activation-update-our-progress-so-far.md
+++ b/_posts/2013-02-06-syria-activation-update-our-progress-so-far.md
@@ -12,7 +12,7 @@ Summary Text: After a week and a half of work on the current Syria activation, w
   that, I've just added the next three jobs to the Tasking Manager:<ul><li><a href="http://tasks.hotosm.org/job/168">Hama</a></li>
 Person: Joseph Reeves
 Working Group: []
-Projects: []
+Project: []
 created: 1360183888
 ---
 

--- a/_posts/2013-02-07-mapping-for-preparedness-in-nepal.md
+++ b/_posts/2013-02-07-mapping-for-preparedness-in-nepal.md
@@ -13,7 +13,7 @@ Summary Text: "<i>Today I bring you a guest post about a great project in Nepal.
   in the Kathmandu Valley alone, injuring another 300,000 and displacing up to 1 million."
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Nepal_Activites.jpg
 created: 1360198238
 ---

--- a/_posts/2013-02-10-faces-of-hot-emir-hartato-one-of-hots-indonesian-team-leaders.md
+++ b/_posts/2013-02-10-faces-of-hot-emir-hartato-one-of-hots-indonesian-team-leaders.md
@@ -12,7 +12,7 @@ Summary Text: "<b>Emir Hartato</b>,22, has been working on the HOT Indonesian te
   has to say about his work with HOT so far:<b>How did you get involved with HOT/OSM?</b>"
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/emr_0.jpg
 created: 1360491111

--- a/_posts/2013-02-11-naissance-dune-communaut-osm-kinshasa.md
+++ b/_posts/2013-02-11-naissance-dune-communaut-osm-kinshasa.md
@@ -10,7 +10,7 @@ Summary Text: Durant les derniers mois, de nombreux contributeurs à travers le 
   réduit de contributeurs actifs à l'intérieur de la RDC.
 Person: Claire Halleux
 Working Group: []
-Projects: []
+Project: []
 created: 1360606812
 ---
 

--- a/_posts/2013-02-12-eurosha-in-kenya-making-up-and-perspectives-for-the-second-hot-support.md
+++ b/_posts/2013-02-12-eurosha-in-kenya-making-up-and-perspectives-for-the-second-hot-support.md
@@ -14,7 +14,7 @@ Summary Text: In Kenya, 6 Eurosha volunteers have been deployed since Early Octo
   of time for safaris.
 Person: Séverin Ménard
 Working Group: []
-Projects:
+Project:
 - EUROSHA
 created: 1360705839
 ---

--- a/_posts/2013-02-20-how-to-engage-with-non-spatial-partners-feedback-from-the-field-in-kenya.md
+++ b/_posts/2013-02-20-how-to-engage-with-non-spatial-partners-feedback-from-the-field-in-kenya.md
@@ -4,7 +4,7 @@ date: 2013-02-20 04:34:58 Z
 permalink: updates/2013-02-20_how_to_engage_with_non-spatial_partners_feedback_from_the_field_in_kenya
 Person: Stéphane Henriod
 Working Group: []
-Projects:
+Project:
 - EUROSHA
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/map_1.png
 created: 1361334898

--- a/_posts/2013-02-21-burundi-maybe-a-small-country-but-great-opportunities-for-open-data-with-eurosha.md
+++ b/_posts/2013-02-21-burundi-maybe-a-small-country-but-great-opportunities-for-open-data-with-eurosha.md
@@ -14,7 +14,7 @@ Summary Text: 'One Eurosha country we did not talk about so far here (sorry for 
   remotely by foreigners, essentially over Bujumbura, sometimes from old Yahoo imagery.  '
 Person: Séverin Ménard
 Working Group: []
-Projects:
+Project:
 - EUROSHA
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/DSC_0231+800x600.jpg
 created: 1361483972

--- a/_posts/2013-02-22-senegal-mapping-in-saint-louis-is-going-well-and-osm_sn-project-getting-stronger.md
+++ b/_posts/2013-02-22-senegal-mapping-in-saint-louis-is-going-well-and-osm_sn-project-getting-stronger.md
@@ -4,7 +4,7 @@ title: 'Senegal : mapping in Saint-Louis is going well and OSM_SN project gettin
 date: 2013-02-22 23:27:24 Z
 permalink: updates/2013-02-22_senegal__mapping_in_saint-louis_is_going_well_and_osm_sn_project_getting_stronge
 Working Group: []
-Projects:
+Project:
 - Senegal
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMAGE+1bis_1.JPG
 created: 1361575644

--- a/_posts/2013-03-04-tax-exempt-in-the-united-states-at-last.md
+++ b/_posts/2013-03-04-tax-exempt-in-the-united-states-at-last.md
@@ -11,7 +11,7 @@ Summary Text: "<h2>Background</h2>HOT has been incorporated as a non-profit in W
   administrative milestone as a young non-profit incorporated in the United States."
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 created: 1362390005
 ---
 

--- a/_posts/2013-03-07-la-communaut-dakaroise-est-rejoint-par-de-nouveaux-mappers.md
+++ b/_posts/2013-03-07-la-communaut-dakaroise-est-rejoint-par-de-nouveaux-mappers.md
@@ -3,7 +3,7 @@ title: La communauté Dakaroise est rejoint par de nouveaux mappers
 date: 2013-03-07 10:35:38 Z
 permalink: updates/2013-03-07_la_communauté_dakaroise_est_rejoint_par_de_nouveaux_mappers
 Working Group: []
-Projects:
+Project:
 - Senegal
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/DSCN0412petit.JPG
 created: 1362652538

--- a/_posts/2013-03-20-learnosm-origin-and-relaunch.md
+++ b/_posts/2013-03-20-learnosm-origin-and-relaunch.md
@@ -10,7 +10,7 @@ Summary Text: 'Today we are excited to announce the relaunch of LearnOSM in conj
   knowledge. '
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - LearnOSM
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/screen_shot_learn.png
 created: 1363795606

--- a/_posts/2013-04-03-starting-osm-in-cap-haitien-haiti.md
+++ b/_posts/2013-04-03-starting-osm-in-cap-haitien-haiti.md
@@ -9,7 +9,7 @@ Summary Text: 'Ten days that I am back in Haiti to start a new HOT project with 
   local group rooted in the University of Limonade. '
 Person: Nicolas Chavent
 Working Group: []
-Projects: []
+Project: []
 created: 1364962475
 ---
 

--- a/_posts/2013-04-11-starting-a-hot-activation-in-central-african-republic.md
+++ b/_posts/2013-04-11-starting-a-hot-activation-in-central-african-republic.md
@@ -12,7 +12,7 @@ Summary Text: 'Bangui, la capitale de la République Centrafricaine, a été pri
 Person: Séverin Ménard
 Working Group:
 - Technical
-Projects:
+Project:
 - Central African Republic Activation
 created: 1365647097
 ---

--- a/_posts/2013-04-24-hottie-humberto-yances-presents-the-la-boquilla-project.md
+++ b/_posts/2013-04-24-hottie-humberto-yances-presents-the-la-boquilla-project.md
@@ -10,7 +10,7 @@ Summary Text: Humberto Yances has written up his <a href="http://www.openstreetm
   these evocative beginnings ...
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1366833654
 ---
 

--- a/_posts/2013-04-25-state-department-launches-imagery-to-the-crowd.md
+++ b/_posts/2013-04-25-state-department-launches-imagery-to-the-crowd.md
@@ -12,7 +12,7 @@ Summary Text: The State Department Humanitarian Information Unit has launched <a
 Person: Mikel Maron
 Working Group:
 - Governance
-Projects: []
+Project: []
 created: 1366911706
 ---
 

--- a/_posts/2013-04-29-comprehensive-report-on-mali-activation.md
+++ b/_posts/2013-04-29-comprehensive-report-on-mali-activation.md
@@ -4,7 +4,7 @@ date: 2013-04-29 21:14:46 Z
 permalink: updates/2013-04-29_comprehensive_report_on_mali_activation
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/mali-report-all-log.png
 created: 1367270086
 ---

--- a/_posts/2013-05-11-crossing-boundaries-by-tracing-buildings-mapping-kathmandu-from-new-york-city.md
+++ b/_posts/2013-05-11-crossing-boundaries-by-tracing-buildings-mapping-kathmandu-from-new-york-city.md
@@ -8,7 +8,7 @@ Summary Text: 'Throughout the day you could hear the simple question - ''Is that
   of a city that seemed so far away from our own. '
 Person: Alyssa Wright
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2013-04-21+16.49.27.jpg
 created: 1368290132
 ---

--- a/_posts/2013-05-27-european-commission-joint-research-center-and-openstreetmap.md
+++ b/_posts/2013-05-27-european-commission-joint-research-center-and-openstreetmap.md
@@ -5,7 +5,7 @@ permalink: updates/2013-05-27_european_commission_joint_research_center_and_open
 Person: Séverin Ménard
 Working Group:
 - Training
-Projects: []
+Project: []
 created: 1369623657
 ---
 

--- a/_posts/2013-05-28-using-motorcycles-to-survey-in-haiti.md
+++ b/_posts/2013-05-28-using-motorcycles-to-survey-in-haiti.md
@@ -11,7 +11,7 @@ Summary Text: Hey All,As part of the CAP103 project, financed by USAID, being ru
   for setting offsets and positions for any aerial imageries.
 Person: Brian Wolford
 Working Group: []
-Projects:
+Project:
 - 'Haiti '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_2619.JPG
 created: 1369753162

--- a/_posts/2013-05-31-openstreetmap-bangladesh-edition.md
+++ b/_posts/2013-05-31-openstreetmap-bangladesh-edition.md
@@ -8,7 +8,7 @@ Summary Text: 'Written with Andrew SalzbergThe recent horrific <a href="http://e
   at the far end of the supply chain. '
 Person: Alyssa Wright
 Working Group: []
-Projects: []
+Project: []
 created: 1370002930
 ---
 

--- a/_posts/2013-06-06-humanitarian-data-model-redux.md
+++ b/_posts/2013-06-06-humanitarian-data-model-redux.md
@@ -6,7 +6,7 @@ Summary Text: ''
 Person: Brian Wolford
 Working Group:
 - Activation
-Projects:
+Project:
 - 'Haiti '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/600185_10200894765605830_1568258984_n.jpg
 created: 1370554965

--- a/_posts/2013-06-14-the-hdm-josm-style-by-hot.md
+++ b/_posts/2013-06-14-the-hdm-josm-style-by-hot.md
@@ -7,7 +7,7 @@ Summary Text: 'One of the unique features of OpenStreetMap is the license to use
   said than done. '
 Person: Will Skora
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/image.jpeg
 created: 1371244061
 ---

--- a/_posts/2013-06-20-faces-of-hot-heather-leson-newest-board-member.md
+++ b/_posts/2013-06-20-faces-of-hot-heather-leson-newest-board-member.md
@@ -13,7 +13,7 @@ Summary Text: This week we caught up with Heather, the newest board member of HO
   with HOT/OSM? </b>
 Person: Katrina E.
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Heatherprofile+(Fun).jpg
 created: 1371741353
 ---

--- a/_posts/2013-06-25-faces-of-hot-jeff-haack-content-writer-of-www-learnosm-org.md
+++ b/_posts/2013-06-25-faces-of-hot-jeff-haack-content-writer-of-www-learnosm-org.md
@@ -12,7 +12,7 @@ Summary Text: Jeff Haack has been working on and off for HOT since its establish
   get involved with HOT/OSM? </b>
 Person: Katrina E.
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Image+1.png
 created: 1372122280
 ---

--- a/_posts/2013-06-28-espace-osm-francophone-au-togo-j4.md
+++ b/_posts/2013-06-28-espace-osm-francophone-au-togo-j4.md
@@ -10,7 +10,7 @@ Summary Text: 'Le quatrième jour de cette mission de lancement du projet Espace
   du projet OpenStreetMap dans ce pays de l''Afrique de l''Ouest. '
 Person: Nicolas Chavent
 Working Group: []
-Projects: []
+Project: []
 created: 1372460072
 ---
 

--- a/_posts/2013-06-28-espace-osm-francophone-in-togo-day4-english-version.md
+++ b/_posts/2013-06-28-espace-osm-francophone-in-togo-day4-english-version.md
@@ -10,7 +10,7 @@ Summary Text: The fourth day of this set up mission of the project Espace OSM Fr
   the OSM project in this country of Western Africa
 Person: Nicolas Chavent
 Working Group: []
-Projects: []
+Project: []
 created: 1372463753
 ---
 

--- a/_posts/2013-07-09-faces-of-hot-iyan-new-indonesian-team-manager.md
+++ b/_posts/2013-07-09-faces-of-hot-iyan-new-indonesian-team-manager.md
@@ -13,7 +13,7 @@ Summary Text: "<b>Yantisa Akhadi</b>, a.k.a Iyan, is the new <b>team manager</b>
   Information Science at the <em>University of Melbourne</em>."
 Person: Katrina E.
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/iyan.png
 created: 1373382516

--- a/_posts/2013-08-13-openstreetmap-sri-lanka.md
+++ b/_posts/2013-08-13-openstreetmap-sri-lanka.md
@@ -4,7 +4,7 @@ date: 2013-08-13 14:34:17 Z
 permalink: updates/2013-08-13_openstreetmap_sri_lanka
 Person: Jeff Haack
 Working Group: []
-Projects: []
+Project: []
 created: 1376404457
 ---
 

--- a/_posts/2013-09-02-open-cities-dhaka-kicks-off.md
+++ b/_posts/2013-09-02-open-cities-dhaka-kicks-off.md
@@ -4,7 +4,7 @@ date: 2013-09-02 04:28:14 Z
 permalink: updates/2013-09-02_open_cities_dhaka_kicks_off
 Person: Jeff Haack
 Working Group: []
-Projects: []
+Project: []
 created: 1378096094
 ---
 

--- a/_posts/2013-09-29-a-new-window-on-openstreetmap-data.md
+++ b/_posts/2013-09-29-a-new-window-on-openstreetmap-data.md
@@ -4,7 +4,7 @@ date: 2013-09-29 13:52:06 Z
 permalink: updates/2013-09-29_a_new_window_on_openstreetmap_data
 Person: Yohan Boniface
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/humanitarian-style.png
 created: 1380462726
 ---

--- a/_posts/2013-10-13-russells-week-one-i-e-project-week-2-ulaanbaatar.md
+++ b/_posts/2013-10-13-russells-week-one-i-e-project-week-2-ulaanbaatar.md
@@ -4,7 +4,7 @@ date: 2013-10-13 06:49:17 Z
 permalink: updates/2013-10-13_russell's_week_one_(ie_project_week_2)_ulaanbaatar
 Person: Russell Deffner
 Working Group: []
-Projects:
+Project:
 - Mongolia, Mapping Ulaanbaatar
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/UBTrainingDay1_2.JPG
 created: 1381646957

--- a/_posts/2013-10-20-keep-from-crumbling-ulaanbaatar-project-week-3.md
+++ b/_posts/2013-10-20-keep-from-crumbling-ulaanbaatar-project-week-3.md
@@ -5,7 +5,7 @@ permalink: updates/2013-10-20_keep_from_crumbling_-_ulaanbaatar_project_week_3
 Person: Russell Deffner
 Working Group:
 - Training
-Projects:
+Project:
 - Mongolia, Mapping Ulaanbaatar
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_0140.JPG
 created: 1382270636

--- a/_posts/2013-10-29-hot-chilly-mapping-ulaanbaatar-project-week-4.md
+++ b/_posts/2013-10-29-hot-chilly-mapping-ulaanbaatar-project-week-4.md
@@ -5,7 +5,7 @@ permalink: updates/2013-10-29_hot_chilly_mapping_-_ulaanbaatar_project_week_4
 Person: Séverin Ménard
 Working Group:
 - Technical
-Projects:
+Project:
 - Mongolia, Mapping Ulaanbaatar
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Mongolia_ITOworld_90days_20131027.png
 created: 1383068859

--- a/_posts/2013-11-05-straighten-our-ways-ulaanbaatar-project-week-5.md
+++ b/_posts/2013-11-05-straighten-our-ways-ulaanbaatar-project-week-5.md
@@ -5,7 +5,7 @@ permalink: updates/2013-11-05_straighten_our_ways_–_ulaanbaatar_project_week_5
 Person: Russell Deffner
 Working Group:
 - Technical
-Projects:
+Project:
 - Mongolia, Mapping Ulaanbaatar
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/DSCN0225crop_0.JPG
 created: 1383677083

--- a/_posts/2013-11-11-remote-hot-activation-in-the-philippines-for-typhoon-yolanda-haiyan.md
+++ b/_posts/2013-11-11-remote-hot-activation-in-the-philippines-for-typhoon-yolanda-haiyan.md
@@ -5,7 +5,7 @@ permalink: updates/2013-11-11_remote_hot_activation_in_the_philippines_for_typho
 Person: Kate Chapman
 Working Group:
 - Technical
-Projects:
+Project:
 - Typhoon Haiyan
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/OpenStreetMap_Activities_for_Typhoon_Haiyan__2013_.png
 created: 1384134044

--- a/_posts/2013-11-18-rponse-dopenstreetmap-au-typhon-haiyan-yolanda.md
+++ b/_posts/2013-11-18-rponse-dopenstreetmap-au-typhon-haiyan-yolanda.md
@@ -4,7 +4,7 @@ date: 2013-11-18 00:18:47 Z
 permalink: updates/2013-11-18_réponse_d'openstreetmap_au_typhon_haiyan_/_yolanda
 Person: Pierre Béland
 Working Group: []
-Projects:
+Project:
 - Typhoon Haiyan
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/openstreetmap-hdm-building-tacloban.png
 created: 1384733927

--- a/_posts/2013-11-22-hot-mapping-party-at-iccm-in-nairobi.md
+++ b/_posts/2013-11-22-hot-mapping-party-at-iccm-in-nairobi.md
@@ -5,7 +5,7 @@ permalink: updates/2013-11-22_hot_mapping_party_at_#iccm_in_nairobi
 Person: Heather Leson
 Working Group:
 - Training
-Projects:
+Project:
 - Typhoon Haiyan
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/HOT_Mapping_Action_Shot_0.jpg
 created: 1385127827

--- a/_posts/2013-12-01-mapping-request-for-carles-area-typhoon-haiyan.md
+++ b/_posts/2013-12-01-mapping-request-for-carles-area-typhoon-haiyan.md
@@ -4,7 +4,7 @@ date: 2013-12-01 10:28:03 Z
 permalink: updates/2013-12-01_mapping_request_for_carles_area_(typhoon_haiyan)
 Person: Heather Leson
 Working Group: []
-Projects:
+Project:
 - Typhoon Haiyan
 created: 1385893683
 ---

--- a/_posts/2013-12-05-openstreetmap-and-yolanda-a-report-from-manila.md
+++ b/_posts/2013-12-05-openstreetmap-and-yolanda-a-report-from-manila.md
@@ -5,7 +5,7 @@ permalink: updates/2013-12-05_openstreetmap_and_yolanda_a_report_from_manila
 Person: Kate Chapman
 Working Group:
 - Security
-Projects:
+Project:
 - Typhoon Haiyan
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/philipinnes-osm-data.png
 created: 1386240105

--- a/_posts/2013-12-17-imagery-for-haiyan.md
+++ b/_posts/2013-12-17-imagery-for-haiyan.md
@@ -4,7 +4,7 @@ date: 2013-12-17 12:53:26 Z
 permalink: updates/2013-12-17_imagery_for_haiyan
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - Typhoon Haiyan
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screenshot.png
 created: 1387284806

--- a/_posts/2013-12-19-2012-financial-filings-posted.md
+++ b/_posts/2013-12-19-2012-financial-filings-posted.md
@@ -4,7 +4,7 @@ date: 2013-12-19 20:38:54 Z
 permalink: updates/2013-12-19_2012_financial_filings_posted
 Person: Schuyler Erle
 Working Group: []
-Projects: []
+Project: []
 created: 1387485534
 ---
 

--- a/_posts/2013-12-27-have-spare-holiday-time-contribute-with-hot-mapping.md
+++ b/_posts/2013-12-27-have-spare-holiday-time-contribute-with-hot-mapping.md
@@ -10,7 +10,7 @@ Summary Text: Many of us have spare quiet moments in the Christmas and New Year 
   in humanitarian crisis right at this moment.
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/christmas-ornament-clip-artred-christmas-tree-ornament---free-clip-art-evnlrav0.png
 created: 1388156896
 ---

--- a/_posts/2014-01-04-thank-you-lokku-and-happy-new-year.md
+++ b/_posts/2014-01-04-thank-you-lokku-and-happy-new-year.md
@@ -4,7 +4,7 @@ date: 2014-01-04 16:49:11 Z
 permalink: updates/2014-01-04_thank_you_lokku_and_happy_new_year
 Person: Harry Wood
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/donate.png
 created: 1388854151
 ---

--- a/_posts/2014-01-05-hot-monitoring-for-the-current-crisis-in-south-sudan.md
+++ b/_posts/2014-01-05-hot-monitoring-for-the-current-crisis-in-south-sudan.md
@@ -4,7 +4,7 @@ date: 2014-01-05 01:07:59 Z
 permalink: updates/2014-01-05_hot_monitoring_for_the_current_crisis_in_south_sudan_
 Person: Séverin Ménard
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Bor_z14_20140105.png
 created: 1388884079
 ---

--- a/_posts/2014-01-14-some-editing-stats-from-the-typhoon-haiyan-response.md
+++ b/_posts/2014-01-14-some-editing-stats-from-the-typhoon-haiyan-response.md
@@ -4,7 +4,7 @@ date: 2014-01-14 11:12:16 Z
 permalink: updates/2014-01-14_some_editing_stats_from_the_typhoon_haiyan_response
 Person: Harry Wood
 Working Group: []
-Projects:
+Project:
 - Typhoon Haiyan
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/haiyan-editing-graph.png
 created: 1389697936

--- a/_posts/2014-01-18-activation-hot-en-rpublique-centrafricaine-tat-de-la-progression.md
+++ b/_posts/2014-01-18-activation-hot-en-rpublique-centrafricaine-tat-de-la-progression.md
@@ -4,7 +4,7 @@ date: 2014-01-18 21:42:49 Z
 permalink: updates/2014-01-18_activation_hot_en_république_centrafricaine__état_de_la_progression
 Person: Séverin Ménard
 Working Group: []
-Projects:
+Project:
 - Central African Republic Activation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/uMap_CAR_OSM_progresses.png
 created: 1390081369

--- a/_posts/2014-01-27-support-haiyan-yolanda-reconstruction-contribute-public-use-uav-drone-imagery.md
+++ b/_posts/2014-01-27-support-haiyan-yolanda-reconstruction-contribute-public-use-uav-drone-imagery.md
@@ -9,7 +9,7 @@ Summary Text: 'An unprecedented number of unmanned aerial vehicles (UAVs) -- dro
   can benefit from these "bird''s eye" views of the typhoon affected areas. '
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - Typhoon Haiyan
 created: 1390789275
 ---

--- a/_posts/2014-02-10-peace-corps-openstreetmap.md
+++ b/_posts/2014-02-10-peace-corps-openstreetmap.md
@@ -4,7 +4,7 @@ date: 2014-02-10 21:08:37 Z
 permalink: updates/2014-02-10_peace_corps_+_openstreetmap
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Webcam-1372355183.png
 created: 1392066517
 ---

--- a/_posts/2014-02-18-learnosm-updates.md
+++ b/_posts/2014-02-18-learnosm-updates.md
@@ -4,7 +4,7 @@ date: 2014-02-18 22:28:39 Z
 permalink: updates/2014-02-18_learnosm_updates
 Person: Jeff Haack
 Working Group: []
-Projects:
+Project:
 - LearnOSM
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/new_learn_osm.png
 created: 1392762519

--- a/_posts/2014-03-10-openstreetmap-on-the-ground-update-from-kathmandu.md
+++ b/_posts/2014-03-10-openstreetmap-on-the-ground-update-from-kathmandu.md
@@ -4,7 +4,7 @@ date: 2014-03-10 10:22:59 Z
 permalink: updates/2014-03-10_openstreetmap_on_the_ground_update_from_kathmandu
 Person: Nama Raj Budhathoki
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2.jpg
 created: 1394446979
 ---

--- a/_posts/2014-03-26-mapping-guinea-help-wanted.md
+++ b/_posts/2014-03-26-mapping-guinea-help-wanted.md
@@ -4,7 +4,7 @@ date: 2014-03-26 14:34:38 Z
 permalink: updates/2014-03-26_mapping_guinea_help_wanted
 Person: Joseph Reeves
 Working Group: []
-Projects:
+Project:
 - West Africa Ebola Epidemic
 created: 1395844478
 ---

--- a/_posts/2014-03-31-2014-west-africa-ebola-outbreak-response.md
+++ b/_posts/2014-03-31-2014-west-africa-ebola-outbreak-response.md
@@ -5,7 +5,7 @@ permalink: updates/2014-03-31_2014_west_africa_ebola_outbreak_response
 Person: Pierre Béland
 Working Group:
 - Governance
-Projects:
+Project:
 - West Africa Ebola Epidemic
 created: 1396266087
 ---

--- a/_posts/2014-03-31-rponse-la-crise-dbola-afrique-de-louest-2014.md
+++ b/_posts/2014-03-31-rponse-la-crise-dbola-afrique-de-louest-2014.md
@@ -4,7 +4,7 @@ date: 2014-03-31 01:59:34 Z
 permalink: updates/2014-03-31_réponse_à_la_crise_d'Ébola_afrique_de_l'ouest_2014
 Person: Pierre Béland
 Working Group: []
-Projects:
+Project:
 - West Africa Ebola Epidemic
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/msf-suisse-ebola-2.png
 created: 1396231174

--- a/_posts/2014-04-01-a-week-in-lubumbashi-drc.md
+++ b/_posts/2014-04-01-a-week-in-lubumbashi-drc.md
@@ -4,7 +4,7 @@ date: 2014-04-01 21:58:56 Z
 permalink: updates/2014-04-01_a_week_in_lubumbashi_(drc)
 Person: Jorieke Vyncke
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/DSC02921.JPG
 created: 1396389536
 ---

--- a/_posts/2014-04-09-back-at-the-opengov-hub.md
+++ b/_posts/2014-04-09-back-at-the-opengov-hub.md
@@ -11,7 +11,7 @@ Summary Text: 'I reason I say "back" in quotes because since the last time I was
   spaces the other we share with Wikimedia Indonesia in Jakarta, Indonesia.  '
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/1397071620130.jpg
 created: 1397072150
 ---

--- a/_posts/2014-04-11-state-of-the-map-us-in-dc.md
+++ b/_posts/2014-04-11-state-of-the-map-us-in-dc.md
@@ -5,7 +5,7 @@ permalink: updates/2014-04-11_state_of_the_map_us_in_dc!
 Person: Kate Chapman
 Working Group:
 - Training
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Boy-and-the-world-image-312x500.jpg
 created: 1397245074
 ---

--- a/_posts/2014-04-15-2014-west-africa-ebola-outbreak-response-second-update.md
+++ b/_posts/2014-04-15-2014-west-africa-ebola-outbreak-response-second-update.md
@@ -4,7 +4,7 @@ date: 2014-04-15 09:59:48 Z
 permalink: updates/2014-04-15_2014_west_africa_ebola_outbreak_response_second_update
 Person: Pierre Béland
 Working Group: []
-Projects:
+Project:
 - West Africa Ebola Epidemic
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/macenta-guinea.png
 created: 1397555988

--- a/_posts/2014-04-16-community-growth-in-indonesia-creating-trainers.md
+++ b/_posts/2014-04-16-community-growth-in-indonesia-creating-trainers.md
@@ -4,7 +4,7 @@ date: 2014-04-16 18:39:23 Z
 permalink: updates/2014-04-16_community_growth_in_indonesia_-_creating_trainers
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/13835766473_2f4a67ee7f_o.jpg
 created: 1397673563

--- a/_posts/2014-04-18-when-birds-of-a-feather-map-together.md
+++ b/_posts/2014-04-18-when-birds-of-a-feather-map-together.md
@@ -5,7 +5,7 @@ permalink: updates/2014-04-18_when_birds_of_a_feather_map_together
 Person: Heather Leson
 Working Group:
 - Activation
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/blog_image.png
 created: 1397834970
 ---

--- a/_posts/2014-04-22-mapping-on-in-haiphong.md
+++ b/_posts/2014-04-22-mapping-on-in-haiphong.md
@@ -4,7 +4,7 @@ date: 2014-04-22 12:17:26 Z
 permalink: updates/2014-04-22_mapping_on_in_haiphong
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/maritime-students-vietnam.jpg
 created: 1398169046
 ---

--- a/_posts/2014-04-25-car-activation-year-2.md
+++ b/_posts/2014-04-25-car-activation-year-2.md
@@ -5,7 +5,7 @@ permalink: updates/2014-04-25_car_activation_year_2
 Person: Séverin Ménard
 Working Group:
 - Community
-Projects:
+Project:
 - Central African Republic Activation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/CAR_Umap_20140425.png
 created: 1398388325

--- a/_posts/2014-04-29-the-roles-of-experts-and-the-public-report-back-from-commons-lab-event.md
+++ b/_posts/2014-04-29-the-roles-of-experts-and-the-public-report-back-from-commons-lab-event.md
@@ -4,7 +4,7 @@ date: 2014-04-29 19:51:03 Z
 permalink: updates/2014-04-29_the_roles_of_experts_and_the_public_-_report_back_from_commons_lab_event
 Person: Kate Chapman
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/cover_osm_quality-724x1024.png
 created: 1398801063
 ---

--- a/_posts/2014-05-08-london-hot-congo-mapathon.md
+++ b/_posts/2014-05-08-london-hot-congo-mapathon.md
@@ -4,7 +4,7 @@ date: 2014-05-08 08:56:13 Z
 permalink: updates/2014-05-08_london_hot_congo_mapathon
 Person: Harry Wood
 Working Group: []
-Projects: []
+Project: []
 created: 1399539373
 ---
 

--- a/_posts/2014-06-14-dispatch-ieee-humanitarian-technology-conference.md
+++ b/_posts/2014-06-14-dispatch-ieee-humanitarian-technology-conference.md
@@ -4,7 +4,7 @@ date: 2014-06-14 12:53:05 Z
 permalink: updates/2014-06-14_dispatch_ieee_humanitarian_technology_conference
 Person: Heather Leson
 Working Group: []
-Projects:
+Project:
 - Typhoon Haiyan
 created: 1402750385
 ---

--- a/_posts/2014-06-18-openstreetmap-training-of-trainers-in-the-philippines.md
+++ b/_posts/2014-06-18-openstreetmap-training-of-trainers-in-the-philippines.md
@@ -5,7 +5,7 @@ permalink: updates/2014-06-18_openstreetmap_training_of_trainers_in_the_philippi
 Person: Emir Hartato
 Working Group:
 - Training
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/10415727_10152452028951101_6542834491982019276_n-2.jpg
 created: 1403067609
 ---

--- a/_posts/2014-07-07-reactivation-of-hot-for-the-ebola-epidemic.md
+++ b/_posts/2014-07-07-reactivation-of-hot-for-the-ebola-epidemic.md
@@ -4,7 +4,7 @@ date: 2014-07-07 01:22:47 Z
 permalink: updates/2014-07-07__reactivation_of_hot_for_the_ebola_epidemic
 Person: Pierre Béland
 Working Group: []
-Projects:
+Project:
 - West Africa Ebola Epidemic
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/amr-dale-kunce-DSCN0846b.JPG
 created: 1404696167

--- a/_posts/2014-07-09-join-hot-in-berlin-at-okfestival.md
+++ b/_posts/2014-07-09-join-hot-in-berlin-at-okfestival.md
@@ -4,7 +4,7 @@ date: 2014-07-09 18:10:29 Z
 permalink: updates/2014-07-09_join_hot_in_berlin_at_okfestival!
 Person: Heather Leson
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/OpenStreetMap_in_Lubumbashi,_Democratic_Republic_of_the_Congo.JPG
 created: 1404929429
 ---

--- a/_posts/2014-07-21-a-new-version-of-tasking-manager.md
+++ b/_posts/2014-07-21-a-new-version-of-tasking-manager.md
@@ -5,7 +5,7 @@ permalink: updates/2014-07-21_a_new_version_of_tasking_manager
 Person: Mikel Maron
 Working Group:
 - Training
-Projects:
+Project:
 - Tasking Manager
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/task_manager_v2_screenshot_CAR_example.png
 created: 1405975803

--- a/_posts/2014-07-27-thank-you-gunner-and-aspiration-tech.md
+++ b/_posts/2014-07-27-thank-you-gunner-and-aspiration-tech.md
@@ -5,7 +5,7 @@ permalink: updates/2014-07-27_thank_you_gunner_and_aspiration_tech
 Person: Heather Leson
 Working Group:
 - Communications
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Gunner+at+HOT+Board+meeting.jpg
 created: 1406501601
 ---

--- a/_posts/2014-08-02-project-in-malawi-starts-in-the-field.md
+++ b/_posts/2014-08-02-project-in-malawi-starts-in-the-field.md
@@ -4,7 +4,7 @@ date: 2014-08-02 12:07:09 Z
 permalink: updates/2014-08-02_project_in_malawi_starts_in_the_field!
 Person: Séverin Ménard
 Working Group: []
-Projects:
+Project:
 - Malawi Flood Preparedness
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/P1040705_50%.JPG
 created: 1406981229

--- a/_posts/2014-08-06-reactivation-of-hot-for-the-ebola-epidemic-second-update.md
+++ b/_posts/2014-08-06-reactivation-of-hot-for-the-ebola-epidemic-second-update.md
@@ -16,7 +16,7 @@ Summary Text: Après la deuxième vague de l'épidémie d'Ebola en juin marquée
   services disponibles.
 Person: Pierre Béland
 Working Group: []
-Projects:
+Project:
 - West Africa Ebola Epidemic
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/umap-tasks-2014-08-01.jpg
 created: 1407287528

--- a/_posts/2014-08-08-who-declares-ebola-outbreak-an-international-public-health-emergency.md
+++ b/_posts/2014-08-08-who-declares-ebola-outbreak-an-international-public-health-emergency.md
@@ -7,7 +7,7 @@ Summary Text: L'Équipe humanitaire Humanitarian OpenStreetMap Team hausse le ni
 Person: Pierre Béland
 Working Group:
 - Training
-Projects:
+Project:
 - West Africa Ebola Epidemic
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/photo-Cosimo-Le-Quaglie-MSF-auto.jpg
 created: 1407531343

--- a/_posts/2014-08-09-osm-workshops-for-project-malawi-week-2.md
+++ b/_posts/2014-08-09-osm-workshops-for-project-malawi-week-2.md
@@ -5,7 +5,7 @@ permalink: updates/2014-08-09_osm_workshops_for_project_malawi_(week_2)
 Person: Maning Sambale
 Working Group:
 - Technical
-Projects:
+Project:
 - Malawi Flood Preparedness
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2014-08-04+12.07.13.jpg
 created: 1407590749

--- a/_posts/2014-08-19-osm-training-in-blantyre-for-project-malawi-week-3.md
+++ b/_posts/2014-08-19-osm-training-in-blantyre-for-project-malawi-week-3.md
@@ -4,7 +4,7 @@ date: 2014-08-19 18:19:48 Z
 permalink: updates/2014-08-19_osm_training_in_blantyre_for_project_malawi_(week_3)
 Person: Emir Hartato
 Working Group: []
-Projects:
+Project:
 - Malawi Flood Preparedness
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/collage.jpg
 created: 1408472388

--- a/_posts/2014-08-21-white-house-innovation-for-disaster-response-and-recovery-initiative-demo-day.md
+++ b/_posts/2014-08-21-white-house-innovation-for-disaster-response-and-recovery-initiative-demo-day.md
@@ -4,7 +4,7 @@ date: 2014-08-21 16:58:34 Z
 permalink: updates/2014-08-21_white_house_innovation_for_disaster_response_and_recovery_initiative_demo_day
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1408640314
 ---
 

--- a/_posts/2014-08-28-fieldwork-begins-in-the-lower-shire-week-4.md
+++ b/_posts/2014-08-28-fieldwork-begins-in-the-lower-shire-week-4.md
@@ -4,7 +4,7 @@ date: 2014-08-28 23:36:30 Z
 permalink: updates/2014-08-28_fieldwork_begins_in_the_lower_shire_(week_4)
 Person: Maning Sambale
 Working Group: []
-Projects:
+Project:
 - Malawi Flood Preparedness
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screenshot+from+2014-08-29+07:26:24.png
 created: 1409268990

--- a/_posts/2014-09-07-fieldwork-in-the-heart-of-shire-week-5.md
+++ b/_posts/2014-09-07-fieldwork-in-the-heart-of-shire-week-5.md
@@ -5,7 +5,7 @@ permalink: updates/2014-09-07_fieldwork_in_the_heart_of_shire_(week_5)
 Person: Séverin Ménard
 Working Group:
 - Training
-Projects:
+Project:
 - Malawi Flood Preparedness
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_20140828_115856119.jpg
 created: 1410133183

--- a/_posts/2014-09-13-fieldwork-in-nsanje-district-weeks-6-7.md
+++ b/_posts/2014-09-13-fieldwork-in-nsanje-district-weeks-6-7.md
@@ -5,7 +5,7 @@ permalink: updates/2014-09-13_fieldwork_in_nsanje_district_(weeks_6_-_7)
 Person: Emir Hartato
 Working Group:
 - Training
-Projects:
+Project:
 - Malawi Flood Preparedness
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/DSC_0306.JPG
 created: 1410648856

--- a/_posts/2014-09-15-mikel-maron-chosen-as-a-presidential-innovation-fellow.md
+++ b/_posts/2014-09-15-mikel-maron-chosen-as-a-presidential-innovation-fellow.md
@@ -4,7 +4,7 @@ date: 2014-09-15 21:06:12 Z
 permalink: updates/2014-09-15_mikel_maron_chosen_as_a_presidential_innovation_fellow
 Person: 'Jaakko Helleranta '
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/PIF_group_photo.jpg
 created: 1410815172
 ---

--- a/_posts/2014-09-27-geong-conference-west-africa-ebola-outbreak-six-months-of-sustained-efforts-by-the-openstreetmap-com.md
+++ b/_posts/2014-09-27-geong-conference-west-africa-ebola-outbreak-six-months-of-sustained-efforts-by-the-openstreetmap-com.md
@@ -6,7 +6,7 @@ permalink: updates/2014-09-27_geong_conference_-_west_africa_ebola_outbreak_-_si
 Person: Pierre Béland
 Working Group:
 - Communications
-Projects:
+Project:
 - West Africa Ebola Epidemic
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Cumulative+objects+created.png
 created: 1411844697

--- a/_posts/2014-10-07-updates-from-indonesia.md
+++ b/_posts/2014-10-07-updates-from-indonesia.md
@@ -4,7 +4,7 @@ date: 2014-10-07 14:30:32 Z
 permalink: updates/2014-10-07_updates_from_indonesia
 Person: Emir Hartato
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/10644870_10153125121658465_3116090092438134384_n.jpg
 created: 1412692232

--- a/_posts/2014-10-12-update-about-car-activation.md
+++ b/_posts/2014-10-12-update-about-car-activation.md
@@ -5,7 +5,7 @@ permalink: updates/2014-10-12_update_about_car_activation
 Person: Séverin Ménard
 Working Group:
 - Activation
-Projects:
+Project:
 - Central African Republic Activation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/uMap_CAR_Activation_20141011.png
 created: 1413078084

--- a/_posts/2014-10-27-interview-on-bbc-world-news.md
+++ b/_posts/2014-10-27-interview-on-bbc-world-news.md
@@ -5,7 +5,7 @@ permalink: updates/2014-10-27_interview_on_bbc_world_news
 Person: Harry Wood
 Working Group:
 - Fundraising
-Projects:
+Project:
 - West Africa Ebola Epidemic
 created: 1414435072
 ---

--- a/_posts/2014-11-05-announcing-the-missing-maps-project.md
+++ b/_posts/2014-11-05-announcing-the-missing-maps-project.md
@@ -4,7 +4,7 @@ date: 2014-11-05 02:57:03 Z
 permalink: updates/2014-11-05_announcing_the_missing_maps_project
 Person: Kate Chapman
 Working Group: []
-Projects:
+Project:
 - Missing Maps
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/process.png
 created: 1415156223

--- a/_posts/2014-11-10-open-cities-mapping-guide-released.md
+++ b/_posts/2014-11-10-open-cities-mapping-guide-released.md
@@ -5,7 +5,7 @@ permalink: updates/2014-11-10_open_cities_mapping_guide_released
 Person: Jeff Haack
 Working Group:
 - Community
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/wb_guide.png
 created: 1415642529
 ---

--- a/_posts/2014-12-05-typhoon-hagupit-ruby-activation-live.md
+++ b/_posts/2014-12-05-typhoon-hagupit-ruby-activation-live.md
@@ -5,7 +5,7 @@ permalink: updates/2014-12-05_typhoon_hagupit_(ruby)_activation_live
 Person: Heather Leson
 Working Group:
 - Community
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Umap+of+Imagery+(Hagupit).jpg
 created: 1417781063
 ---

--- a/_posts/2014-12-19-support-hot-with-an-annual-donation.md
+++ b/_posts/2014-12-19-support-hot-with-an-annual-donation.md
@@ -4,7 +4,7 @@ date: 2014-12-19 14:38:50 Z
 permalink: updates/2014-12-19_support_hot_with_an_annual_donation
 Person: Heather Leson
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/missing+maps+London++(Dec.+2014).jpg
 created: 1418999930
 ---

--- a/_posts/2014-12-30-mapzen-donation.md
+++ b/_posts/2014-12-30-mapzen-donation.md
@@ -3,7 +3,7 @@ title: Mapzen Donation!
 date: 2014-12-30 17:38:59 Z
 permalink: updates/2014-12-30_mapzen_donation!
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/mapzen_logo_hover.png
 created: 1419961139
 ---

--- a/_posts/2015-01-13-cristiano-giovando-joins-hot-to-lead-openaerialmap-efforts.md
+++ b/_posts/2015-01-13-cristiano-giovando-joins-hot-to-lead-openaerialmap-efforts.md
@@ -5,7 +5,7 @@ permalink: updates/2015-01-13_cristiano_giovando_joins_hot_to_lead_openaerialmap
 Person: Kate Chapman
 Working Group:
 - Training
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_8849_Cri.jpg
 created: 1421181502
 ---

--- a/_posts/2015-01-21-people-we-can-count-on-thank-you-again-lokku.md
+++ b/_posts/2015-01-21-people-we-can-count-on-thank-you-again-lokku.md
@@ -4,7 +4,7 @@ date: 2015-01-21 23:08:53 Z
 permalink: updates/2015-01-21__people_we_can_count_on_thank_you_again_lokku!
 Person: Blake Girardot
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/lokku_sprite.png
 created: 1421881733
 ---

--- a/_posts/2015-01-24-first-official-missing-maps-field-mapping.md
+++ b/_posts/2015-01-24-first-official-missing-maps-field-mapping.md
@@ -4,7 +4,7 @@ date: 2015-01-24 19:31:30 Z
 permalink: updates/2015-01-24_first_official_missing_maps_field_mapping!
 Person: Jorieke Vyncke
 Working Group: []
-Projects:
+Project:
 - Missing Maps
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/10382623_10202632159000013_5184172476893308300_n.jpg
 created: 1422127890

--- a/_posts/2015-02-20-welcome-new-members.md
+++ b/_posts/2015-02-20-welcome-new-members.md
@@ -4,7 +4,7 @@ date: 2015-02-20 22:59:23 Z
 permalink: updates/2015-02-20_welcome_new_members!
 Person: Russell Deffner
 Working Group: []
-Projects: []
+Project: []
 created: 1424473163
 ---
 

--- a/_posts/2015-02-26-hot-called-upon-to-support-disaster-response-in-malawi-flooding.md
+++ b/_posts/2015-02-26-hot-called-upon-to-support-disaster-response-in-malawi-flooding.md
@@ -11,7 +11,7 @@ Summary Text: The southern parts of Malawi along the Lower Shire River (that con
 Person: Séverin Ménard
 Working Group:
 - Activation
-Projects:
+Project:
 - Malawi Flood Preparedness
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Malawi_washed_away_bridge_Chanasa.png
 created: 1424992687

--- a/_posts/2015-02-26-updates-from-the-openaerialmap-project.md
+++ b/_posts/2015-02-26-updates-from-the-openaerialmap-project.md
@@ -4,7 +4,7 @@ date: 2015-02-26 01:50:32 Z
 permalink: updates/2015-02-26_updates_from_the_openaerialmap_project
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 created: 1424915432
 ---

--- a/_posts/2015-03-06-taller-de-mapeo-humanitario-isla-de-len-colombia.md
+++ b/_posts/2015-03-06-taller-de-mapeo-humanitario-isla-de-len-colombia.md
@@ -5,7 +5,7 @@ permalink: updates/2015-03-06_taller_de_mapeo_humanitario_–_isla_de_león_colo
 Person: Blake Girardot
 Working Group:
 - Fundraising
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Taller+de+Mapeo+Humanitario01.jpg
 created: 1425664539
 ---

--- a/_posts/2015-03-16-mapping-vanuatu-islands.md
+++ b/_posts/2015-03-16-mapping-vanuatu-islands.md
@@ -5,7 +5,7 @@ permalink: updates/2015-03-16_mapping_vanuatu_islands
 Person: Heather Leson
 Working Group:
 - Activation
-Projects: []
+Project: []
 created: 1426482517
 ---
 

--- a/_posts/2015-03-17-humanitarian-openstreetmap-team-seeks-interim-executive-director.md
+++ b/_posts/2015-03-17-humanitarian-openstreetmap-team-seeks-interim-executive-director.md
@@ -5,7 +5,7 @@ permalink: updates/2015-03-17_humanitarian_openstreetmap_team_seeks_interim_exec
 Person: Heather Leson
 Working Group:
 - Fundraising
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/120px-Hot_logo.svg_.png
 created: 1426615844
 ---

--- a/_posts/2015-03-24-osm-tanzania.md
+++ b/_posts/2015-03-24-osm-tanzania.md
@@ -5,8 +5,8 @@ permalink: updates/2015-03-24_osm_tanzania
 Person: Steven Bukulu
 Working Group:
 - Technical
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 created: 1427175756
 ---
 

--- a/_posts/2015-03-25-osm-tanzania.md
+++ b/_posts/2015-03-25-osm-tanzania.md
@@ -4,8 +4,8 @@ date: 2015-03-25 18:52:50 Z
 permalink: updates/2015-03-25_osm_tanzania
 Person: Steven Bukulu
 Working Group: []
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 created: 1427309570
 ---
 

--- a/_posts/2015-04-10-hot-says-farewell-to-our-kate.md
+++ b/_posts/2015-04-10-hot-says-farewell-to-our-kate.md
@@ -4,7 +4,7 @@ date: 2015-04-10 03:02:37 Z
 permalink: updates/2015-04-10_hot_says_farewell_to_our_kate
 Person: Kristen Egermeier
 Working Group: []
-Projects: []
+Project: []
 created: 1428634957
 ---
 

--- a/_posts/2015-04-22-updates-from-dar-es-salaam.md
+++ b/_posts/2015-04-22-updates-from-dar-es-salaam.md
@@ -5,8 +5,8 @@ permalink: updates/2015-04-22_updates_from__dar_es_salaam
 Person: Geoffrey Kateregga
 Working Group:
 - Activation
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 created: 1429729855
 ---
 

--- a/_posts/2015-04-25-strong-earthquake-in-nepal-hot-activates-report-1.md
+++ b/_posts/2015-04-25-strong-earthquake-in-nepal-hot-activates-report-1.md
@@ -5,7 +5,7 @@ permalink: updates/2015-04-25_strong_earthquake_in_nepal_-_hot_activates!__repor
 Person: Russell Deffner
 Working Group:
 - Activation
-Projects:
+Project:
 - Nepal 2015 Earthquake Response
 created: 1429975742
 ---

--- a/_posts/2015-04-26-hot-activates-for-nepal-response-report-2.md
+++ b/_posts/2015-04-26-hot-activates-for-nepal-response-report-2.md
@@ -5,7 +5,7 @@ permalink: updates/2015-04-26_hot_activates_for_nepal_response_-_report_#2
 Person: Heather Leson
 Working Group:
 - Technical
-Projects:
+Project:
 - Nepal 2015 Earthquake Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Katmandu+Living+Labs+for+Nepal+Earthquake.png
 created: 1430028311

--- a/_posts/2015-04-28-openstreetmap-community-india-rallies-in-aid-of-their-neighbor-nepal-report-3.md
+++ b/_posts/2015-04-28-openstreetmap-community-india-rallies-in-aid-of-their-neighbor-nepal-report-3.md
@@ -6,7 +6,7 @@ permalink: updates/2015-04-28_openstreetmap_community_india_rallies_in_aid_of_th
 Person: Heather Leson
 Working Group:
 - Community
-Projects:
+Project:
 - Nepal 2015 Earthquake Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Mapping+Nepal+photo+by+Gopinath+Parayil.png
 created: 1430216884

--- a/_posts/2015-04-29-processing-fresh-imagery-for-nepal-earthquake-response.md
+++ b/_posts/2015-04-29-processing-fresh-imagery-for-nepal-earthquake-response.md
@@ -7,7 +7,7 @@ Summary Text: We are heads down on processing imagery from DigitalGlobe, Airbus 
   have processed and made available over 3,000 square kilometers of updated imagery!
 Person: Cristiano Giovando
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/ab-np-image-1.png
 created: 1430276403
 ---

--- a/_posts/2015-04-30-helping-to-map-nepal-getting-started.md
+++ b/_posts/2015-04-30-helping-to-map-nepal-getting-started.md
@@ -5,7 +5,7 @@ permalink: updates/2015-04-30_helping_to_map_nepal_getting_started
 Person: Heather Leson
 Working Group:
 - Activation
-Projects:
+Project:
 - Nepal 2015 Earthquake Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/tm+squares+blog.png
 created: 1430368401

--- a/_posts/2015-04-30-volunteers-from-around-the-world-help-hot-map-nepal.md
+++ b/_posts/2015-04-30-volunteers-from-around-the-world-help-hot-map-nepal.md
@@ -7,7 +7,7 @@ Summary Text: Volunteers from around the world have been helping map Nepal -- he
 Person: Andrew Wiseman
 Working Group:
 - Community
-Projects:
+Project:
 - Nepal 2015 Earthquake Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/dcmapper.jpg
 created: 1430405205

--- a/_posts/2015-04-30-welcome-tyler.md
+++ b/_posts/2015-04-30-welcome-tyler.md
@@ -5,7 +5,7 @@ permalink: updates/2015-04-30_welcome_tyler!
 Person: Heather Leson
 Working Group:
 - Training
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Tyler+(HOT)+April+29,+2015.png
 created: 1430393475
 ---

--- a/_posts/2015-05-01-kathmandu-living-labs-is-working-to-respond-in-nepal-help-them-out.md
+++ b/_posts/2015-05-01-kathmandu-living-labs-is-working-to-respond-in-nepal-help-them-out.md
@@ -8,7 +8,7 @@ Summary Text: Kathmandu Living Labs is a great local non-profit working to help 
 Person: Andrew Wiseman
 Working Group:
 - Activation
-Projects:
+Project:
 - Nepal 2015 Earthquake Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/kll_crowdsourcing.jpg
 created: 1430497874

--- a/_posts/2015-05-01-nepal-earthquake-we-have-maps.md
+++ b/_posts/2015-05-01-nepal-earthquake-we-have-maps.md
@@ -5,7 +5,7 @@ permalink: updates/2015-05-01_nepal_earthquake_we_have_maps
 Person: Harry Wood
 Working Group:
 - Fundraising
-Projects:
+Project:
 - Nepal 2015 Earthquake Response
 created: 1430444563
 ---

--- a/_posts/2015-05-07-mongolia-mapping-ulaanbaatar-update-welcome-interns.md
+++ b/_posts/2015-05-07-mongolia-mapping-ulaanbaatar-update-welcome-interns.md
@@ -10,7 +10,7 @@ Summary Text: It is our pleasure to welcome a group of student interns from the 
   of Ulaanbaatar to create and maintain a map of the city within OpenStreetMap (OSM).
 Person: Russell Deffner
 Working Group: []
-Projects:
+Project:
 - Mongolia, Mapping Ulaanbaatar
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/MUST.JPG
 created: 1430976687

--- a/_posts/2015-05-12-recent-flooding-in-dar-es-salaam-shows-need-for-maps.md
+++ b/_posts/2015-05-12-recent-flooding-in-dar-es-salaam-shows-need-for-maps.md
@@ -5,8 +5,8 @@ permalink: updates/2015-05-12_recent_flooding_in_dar_es_salaam_shows_need_for_ma
 Person: Geoffrey Kateregga
 Working Group:
 - Training
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_1253+(1).JPG
 created: 1431419685
 ---

--- a/_posts/2015-05-18-a-warm-welcome-to-the-outreachy-hot-interns.md
+++ b/_posts/2015-05-18-a-warm-welcome-to-the-outreachy-hot-interns.md
@@ -12,7 +12,7 @@ Summary Text: 'The Humanitarian OpenStreetMap Team (HOT) and the OpenStreetMap (
 Person: Mhairi O'Hara
 Working Group:
 - Communications
-Projects:
+Project:
 - Outreachy
 created: 1431963906
 ---

--- a/_posts/2015-05-27-global-studies-and-collaboration-with-crisismappers-japan.md
+++ b/_posts/2015-05-27-global-studies-and-collaboration-with-crisismappers-japan.md
@@ -10,7 +10,7 @@ Summary Text: On April 28, 2015, Prof. Furuhashi, of Aoyama Gakuin University's 
 Person: Heather Leson
 Working Group:
 - Community
-Projects:
+Project:
 - Nepal 2015 Earthquake Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Crisismappers+Japan+1.png
 created: 1432754788

--- a/_posts/2015-05-27-help-improve-mapping-take-hots-community-survey.md
+++ b/_posts/2015-05-27-help-improve-mapping-take-hots-community-survey.md
@@ -4,7 +4,7 @@ date: 2015-05-27 17:03:16 Z
 permalink: updates/2015-05-27_help_improve_mapping_take_hot's_community_survey
 Person: Tyler Radford
 Working Group: []
-Projects:
+Project:
 - Nepal 2015 Earthquake Response
 created: 1432746196
 ---

--- a/_posts/2015-05-28-hot-attends-first-white-house-mapathon.md
+++ b/_posts/2015-05-28-hot-attends-first-white-house-mapathon.md
@@ -4,7 +4,7 @@ date: 2015-05-28 20:44:06 Z
 permalink: updates/2015-05-28_hot_attends_first_white_house_mapathon
 Person: Steven Johnson
 Working Group: []
-Projects: []
+Project: []
 created: 1432845846
 ---
 

--- a/_posts/2015-05-28-your-neighbour-is-mapping.md
+++ b/_posts/2015-05-28-your-neighbour-is-mapping.md
@@ -4,7 +4,7 @@ date: 2015-05-28 14:55:47 Z
 permalink: updates/2015-05-28_your_neighbour_is_mapping
 Person: Kristen Egermeier
 Working Group: []
-Projects: []
+Project: []
 created: 1432824947
 ---
 

--- a/_posts/2015-05-29-openaerialmap-beta-goes-live.md
+++ b/_posts/2015-05-29-openaerialmap-beta-goes-live.md
@@ -4,7 +4,7 @@ date: 2015-05-29 02:14:03 Z
 permalink: updates/2015-05-29_openaerialmap_beta_goes_live
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/oam_beta_pre.jpg
 created: 1432865643

--- a/_posts/2015-06-05-the-new-field-papers-site-is-live.md
+++ b/_posts/2015-06-05-the-new-field-papers-site-is-live.md
@@ -13,7 +13,7 @@ Summary Text: The new Field Papers site has been live for over a week now, as it
   of your desired language.
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - Field Papers
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/FieldPapers.png
 created: 1433473109

--- a/_posts/2015-06-23-case-study-humanitarian-openstreetmap-team.md
+++ b/_posts/2015-06-23-case-study-humanitarian-openstreetmap-team.md
@@ -4,7 +4,7 @@ date: 2015-06-23 15:09:28 Z
 permalink: updates/2015-06-23_case_study_humanitarian_openstreetmap_team
 Person: Felix Delattre
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/osm_rescueteam.jpg
 created: 1435072168
 ---

--- a/_posts/2015-06-26-tomtom-june-2015-hot-mapathon.md
+++ b/_posts/2015-06-26-tomtom-june-2015-hot-mapathon.md
@@ -5,7 +5,7 @@ permalink: updates/2015-06-26_tomtom_june_2015_hot_mapathon
 Person: Pierre Mirlesse
 Working Group:
 - Communications
-Projects:
+Project:
 - Nepal 2015 Earthquake Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/20150623_091011.jpg
 created: 1435336166

--- a/_posts/2015-07-02-be-the-executive-director-of-humanitarian-openstreetmap-team.md
+++ b/_posts/2015-07-02-be-the-executive-director-of-humanitarian-openstreetmap-team.md
@@ -4,7 +4,7 @@ date: 2015-07-02 14:54:18 Z
 permalink: updates/2015-07-02_be_the_executive_director_of_humanitarian_openstreetmap_team
 Person: Heather Leson
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/hot-logo-white-bg+(1)+(1).png
 created: 1435848858
 ---

--- a/_posts/2015-07-03-mapping-ulaanbaatar-with-asia-foundation.md
+++ b/_posts/2015-07-03-mapping-ulaanbaatar-with-asia-foundation.md
@@ -10,7 +10,7 @@ Summary Text: Recently we had a very pleasant surprise to be contacted by Nichol
 Person: Russell Deffner
 Working Group:
 - Security
-Projects:
+Project:
 - Mongolia, Mapping Ulaanbaatar
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/11422721_880758605351234_60885064_n.jpg
 created: 1435936166

--- a/_posts/2015-07-08-hot-leadership-2015.md
+++ b/_posts/2015-07-08-hot-leadership-2015.md
@@ -8,7 +8,7 @@ Summary Text: 'This year has presented many challenges to HOT. We have been incr
   change in HOT leadership.'
 Person: Russell Deffner
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/hotlogo.png
 created: 1436372673
 ---

--- a/_posts/2015-07-14-nepal-earthquake-a-note-of-thanks-to-hots-aerial-imagery-providers.md
+++ b/_posts/2015-07-14-nepal-earthquake-a-note-of-thanks-to-hots-aerial-imagery-providers.md
@@ -4,7 +4,7 @@ date: 2015-07-14 13:42:15 Z
 permalink: updates/2015-07-14_nepal_earthquake_a_note_of_thanks_to_hot’s_aerial_imagery_providers
 Person: Tyler Radford
 Working Group: []
-Projects:
+Project:
 - Nepal 2015 Earthquake Response
 created: 1436881335
 ---

--- a/_posts/2015-07-17-ramani-huria-scale-up-dar-es-salaam-6th-july-2015.md
+++ b/_posts/2015-07-17-ramani-huria-scale-up-dar-es-salaam-6th-july-2015.md
@@ -4,8 +4,8 @@ date: 2015-07-17 08:37:54 Z
 permalink: updates/2015-07-17_ramani_huria_scale_up_-_dar_es_salaam_6th_july_2015
 Person: Paul Uithol
 Working Group: []
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/1.jpg
 created: 1437122274
 ---

--- a/_posts/2015-07-23-pilot-workshops-hot-activation-curriculum.md
+++ b/_posts/2015-07-23-pilot-workshops-hot-activation-curriculum.md
@@ -4,7 +4,7 @@ date: 2015-07-23 08:54:38 Z
 permalink: updates/2015-07-23_pilot_workshops_-_hot_activation_curriculum_
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - HOT Training Center
 created: 1437641678
 ---

--- a/_posts/2015-07-24-oam-adds-dynamic-filtering-upload-tools-coming-soon.md
+++ b/_posts/2015-07-24-oam-adds-dynamic-filtering-upload-tools-coming-soon.md
@@ -4,7 +4,7 @@ date: 2015-07-24 07:31:00 Z
 permalink: updates/2015-07-24_oam_adds_dynamic_filtering_upload_tools_coming_soon
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2015-07-24+at+00.13.20.png
 created: 1437723060

--- a/_posts/2015-08-07-hotsummit-videos-are-live.md
+++ b/_posts/2015-08-07-hotsummit-videos-are-live.md
@@ -4,7 +4,7 @@ date: 2015-08-07 17:55:55 Z
 permalink: updates/2015-08-07_#hotsummit_videos_are_live!
 Person: Kristen Egermeier
 Working Group: []
-Projects: []
+Project: []
 created: 1438970155
 ---
 

--- a/_posts/2015-08-09-ramani-huria-community-mapping-showcased-to-tanzanian-president-jakaya-kikwete.md
+++ b/_posts/2015-08-09-ramani-huria-community-mapping-showcased-to-tanzanian-president-jakaya-kikwete.md
@@ -8,8 +8,8 @@ Summary Text: La quatrième conférence annuelle nationale Tanzanienne des scien
   Huria de Dar es Salaam au President de la république de Tanzanie, Jakaya Kikwete.
 Person: Sophie Lafayette
 Working Group: []
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/CIQ2a_CXAAAdvcq-1024x768.jpg
 created: 1439140842
 ---

--- a/_posts/2015-08-13-small-uas-for-humanitarian-mapping.md
+++ b/_posts/2015-08-13-small-uas-for-humanitarian-mapping.md
@@ -4,7 +4,7 @@ date: 2015-08-13 00:00:36 Z
 permalink: updates/2015-08-13_small_uas_for_humanitarian_mapping
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/ebee.png
 created: 1439424036

--- a/_posts/2015-08-18-community-mapping-can-greatly-contribute-to-the-development-of-dar-es-salaam.md
+++ b/_posts/2015-08-18-community-mapping-can-greatly-contribute-to-the-development-of-dar-es-salaam.md
@@ -9,8 +9,8 @@ Summary Text: Mr. Monday Anthony, a 66 year old  community member of Mchikichini
   Mchikichini.
 Person: Sophie Lafayette
 Working Group: []
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Monday-Anthony.jpg
 created: 1439895148
 ---

--- a/_posts/2015-08-27-end-of-the-outreachy-program-round-10.md
+++ b/_posts/2015-08-27-end-of-the-outreachy-program-round-10.md
@@ -4,7 +4,7 @@ date: 2015-08-27 10:35:27 Z
 permalink: updates/2015-08-27_end_of_the_outreachy_program_round_10
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - Outreachy
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/save.png
 created: 1440671727

--- a/_posts/2015-08-31-alpha-release-of-the-redeveloped-export-tool.md
+++ b/_posts/2015-08-31-alpha-release-of-the-redeveloped-export-tool.md
@@ -4,7 +4,7 @@ date: 2015-08-31 19:40:27 Z
 permalink: updates/2015-08-31_alpha_release_of_the_redeveloped_export_tool_
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - Export Tool
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/export_tool.png
 created: 1441050027

--- a/_posts/2015-08-31-open-data-open-mapping-teachosm-in-the-caribbean.md
+++ b/_posts/2015-08-31-open-data-open-mapping-teachosm-in-the-caribbean.md
@@ -4,7 +4,7 @@ date: 2015-08-31 17:02:03 Z
 permalink: updates/2015-08-31_open_data_open_mapping_teachosm_in_the_caribbean
 Person: Steven Johnson
 Working Group: []
-Projects:
+Project:
 - HOT Training Center
 created: 1441040523
 ---

--- a/_posts/2015-09-08-activation-workshop-at-africa-open-data-conference.md
+++ b/_posts/2015-09-08-activation-workshop-at-africa-open-data-conference.md
@@ -10,7 +10,7 @@ Summary Text: The first workshop for the HOT Activation Curriculum was held duri
 Person: Russell Deffner
 Working Group:
 - Activation
-Projects:
+Project:
 - HOT Training Center
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/activation.jpg
 created: 1441738671

--- a/_posts/2015-09-14-ramani-huria-at-the-africa-open-data-conference.md
+++ b/_posts/2015-09-14-ramani-huria-at-the-africa-open-data-conference.md
@@ -9,8 +9,8 @@ Summary Text: The Ramani Huria team was proud to be part of the first Africa Ope
   across Africa.’
 Person: Paul Uithol
 Working Group: []
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/rtDjzoSk_pdaHJIptNLqGBrek22PC8KQ-DROyGI9sAFbJB4j-rjaYm8Xz0Ppf1xF_Kxrq3qm4s.jpg
 created: 1442273509
 ---

--- a/_posts/2015-09-21-making-a-difference-from-afar.md
+++ b/_posts/2015-09-21-making-a-difference-from-afar.md
@@ -4,7 +4,7 @@ date: 2015-09-21 14:05:50 Z
 permalink: updates/2015-09-21_making_a_difference__from_afar
 Person: Kristen Egermeier
 Working Group: []
-Projects: []
+Project: []
 created: 1442844350
 ---
 

--- a/_posts/2015-09-23-beta-release-of-the-redeveloped-export-tool.md
+++ b/_posts/2015-09-23-beta-release-of-the-redeveloped-export-tool.md
@@ -5,7 +5,7 @@ permalink: updates/2015-09-23_beta_release_of_the_redeveloped_export_tool
 Person: Mhairi O'Hara
 Working Group:
 - Technical
-Projects:
+Project:
 - Export Tool
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/osm.png
 created: 1442983549

--- a/_posts/2015-09-23-community-mapping-has-long-lasting-impact-in-tandale-dar-es-salaam-tanzania.md
+++ b/_posts/2015-09-23-community-mapping-has-long-lasting-impact-in-tandale-dar-es-salaam-tanzania.md
@@ -9,8 +9,8 @@ Summary Text: The ward of Tandale was one of the first wards in Dar es Salaam to
   mapping.
 Person: Sophie Lafayette
 Working Group: []
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/tandaleblog1.png
 created: 1443000773
 ---

--- a/_posts/2015-10-01-outreachy-presentation-hot-osm-round-10.md
+++ b/_posts/2015-10-01-outreachy-presentation-hot-osm-round-10.md
@@ -4,7 +4,7 @@ date: 2015-10-01 09:42:44 Z
 permalink: updates/2015-10-01_outreachy_presentation_|_hot_osm_round_10
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - Outreachy
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/youtube.png
 created: 1443692564

--- a/_posts/2015-10-02-hot-announces-tyler-radford-as-our-executive-director.md
+++ b/_posts/2015-10-02-hot-announces-tyler-radford-as-our-executive-director.md
@@ -5,7 +5,7 @@ permalink: updates/2015-10-02_hot_announces_tyler_radford_as_our_executive_direc
 Person: Heather Leson
 Working Group:
 - Community
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Tyler+dar+2(1).jpg
 created: 1443817348
 ---

--- a/_posts/2015-10-06-the-new-osm-export-tool-is-live.md
+++ b/_posts/2015-10-06-the-new-osm-export-tool-is-live.md
@@ -4,7 +4,7 @@ date: 2015-10-06 15:02:45 Z
 permalink: updates/2015-10-06_the_new_osm_export_tool_is_live
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - Export Tool
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/export_tool.png
 created: 1444143765

--- a/_posts/2015-10-09-join-100mapathons-for-osmgeoweek-2015.md
+++ b/_posts/2015-10-09-join-100mapathons-for-osmgeoweek-2015.md
@@ -8,7 +8,7 @@ Summary Text: La semaine internationale de sensibilisation à la géographie (Ge
   participer massivement cette année !
 Person: Pete Masters
 Working Group: []
-Projects:
+Project:
 - Missing Maps
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/mapathon_Bangladesh_Jan15.jpg
 created: 1444391997

--- a/_posts/2015-10-23-hot-activation-hurricane-patricia.md
+++ b/_posts/2015-10-23-hot-activation-hurricane-patricia.md
@@ -5,7 +5,7 @@ permalink: updates/2015-10-23_hot_activation_hurricane_patricia
 Person: Dale Kunce
 Working Group:
 - Activation
-Projects:
+Project:
 - Hurricane Patricia
 created: 1445622109
 ---

--- a/_posts/2015-10-25-updates-and-info-on-hots-hurricane-patricia-mapping-from-the-activation-team.md
+++ b/_posts/2015-10-25-updates-and-info-on-hots-hurricane-patricia-mapping-from-the-activation-team.md
@@ -13,7 +13,7 @@ Summary Text: 'HOT, en coordinación con la comunidad mexicana de OSM, ha sido a
 Person: Blake Girardot
 Working Group:
 - Activation
-Projects:
+Project:
 - Hurricane Patricia
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/EMSR144-copernicus.jpg
 created: 1445781470

--- a/_posts/2015-10-28-eastern-afghanistan-earthquake-day-1.md
+++ b/_posts/2015-10-28-eastern-afghanistan-earthquake-day-1.md
@@ -7,7 +7,7 @@ Summary Text: Humanitarian OpenStreetMap Team (HOT) calls upon our community to 
 Person: Russell Deffner
 Working Group:
 - Activation
-Projects:
+Project:
 - Eastern Afghanistan Earthquake
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/AfghanEarthquakeDay1.PNG
 created: 1446005278

--- a/_posts/2015-10-29-eastern-afghanistan-earthquake-day-2.md
+++ b/_posts/2015-10-29-eastern-afghanistan-earthquake-day-2.md
@@ -9,7 +9,7 @@ Summary Text: Since the Humanitarian OpenStreetMap Team (HOT) officially activat
 Person: Mhairi O'Hara
 Working Group:
 - Activation
-Projects:
+Project:
 - Eastern Afghanistan Earthquake
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/OSM+Changesets-resized.png
 created: 1446090332

--- a/_posts/2015-11-04-old-export-tool-moving-to-hot-servers-as-read-only-copy.md
+++ b/_posts/2015-11-04-old-export-tool-moving-to-hot-servers-as-read-only-copy.md
@@ -4,7 +4,7 @@ date: 2015-11-04 10:14:25 Z
 permalink: updates/2015-11-04_old_export_tool_moving_to_hot_servers_as_read-only_copy
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - Export Tool
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/export_tool.png
 created: 1446632065

--- a/_posts/2015-11-06-hot-launches-50000-crowdfunding-campaign-donate-today.md
+++ b/_posts/2015-11-06-hot-launches-50000-crowdfunding-campaign-donate-today.md
@@ -4,7 +4,7 @@ date: 2015-11-06 15:41:36 Z
 permalink: updates/2015-11-06_hot_launches_$50000_crowdfunding_campaign_-_donate_today!
 Person: Tyler Radford
 Working Group: []
-Projects:
+Project:
 - Donate to HOT today
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/twitter-card-large.jpg
 created: 1446824496

--- a/_posts/2015-11-15-dont-get-left-behind.md
+++ b/_posts/2015-11-15-dont-get-left-behind.md
@@ -9,7 +9,7 @@ Summary Text: 'The buzz of Geography Awareness Week, has reached far corners of 
 Person: Russell Deffner
 Working Group:
 - Community
-Projects:
+Project:
 - Missing Maps
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/ZimbabweRC.png
 created: 1447611004

--- a/_posts/2015-11-19-hewlett-foundation-grant-summary-ebola-epidemic-response.md
+++ b/_posts/2015-11-19-hewlett-foundation-grant-summary-ebola-epidemic-response.md
@@ -11,7 +11,7 @@ Summary Text: Inspired by our response to the West Africa Ebola epidemic, a gran
   as well as building the numbers of Activation Coordinators.
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - West Africa Ebola Epidemic
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Ebola.png
 created: 1447913508

--- a/_posts/2015-11-19-mapping-drainage-in-dar-es-salaam.md
+++ b/_posts/2015-11-19-mapping-drainage-in-dar-es-salaam.md
@@ -12,8 +12,8 @@ Summary Text: Every year during the rainy season, the largest city in Tanzania, 
   in our maps.
 Person: Sophie Lafayette
 Working Group: []
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/drainage-map.png
 created: 1447939018
 ---

--- a/_posts/2015-12-09-access-to-open-imagery-innovation-and-openaerialmap.md
+++ b/_posts/2015-12-09-access-to-open-imagery-innovation-and-openaerialmap.md
@@ -4,7 +4,7 @@ date: 2015-12-09 04:48:42 Z
 permalink: updates/2015-12-09_access_to_open_imagery_innovation_and_openaerialmap
 Person: Tyler Radford
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Figure-1-OAM-Catalog-1024x591.png
 created: 1449636522

--- a/_posts/2015-12-28-hot-indonesia-year-4-leveraging-inasafe-and-osm-to-enhance-disaster-preparedness.md
+++ b/_posts/2015-12-28-hot-indonesia-year-4-leveraging-inasafe-and-osm-to-enhance-disaster-preparedness.md
@@ -4,7 +4,7 @@ date: 2015-12-28 07:44:25 Z
 permalink: updates/2015-12-28_hot_indonesia_year_4_leveraging_inasafe_and_osm_to_enhance_disaster_preparedness
 Person: Yantisa Akhadi
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/InaSAFE_EN_New.PNG
 created: 1451288665

--- a/_posts/2015-12-30-mapping-financial-services-in-uganda-starting-january-2016.md
+++ b/_posts/2015-12-30-mapping-financial-services-in-uganda-starting-january-2016.md
@@ -20,7 +20,7 @@ Summary Text: 'As we near the end of the year, there’s many stories that stand
   and mapping process.'
 Person: Paul Uithol
 Working Group: []
-Projects:
+Project:
 - Mapping Financial Inclusion in Uganda
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_20151215_184503.jpg
 created: 1451488312

--- a/_posts/2015-12-31-2015-hot-in-numbers.md
+++ b/_posts/2015-12-31-2015-hot-in-numbers.md
@@ -4,7 +4,7 @@ date: 2015-12-31 19:27:09 Z
 permalink: updates/2015-12-31_2015_hot_in_numbers
 Person: Tyler Radford
 Working Group: []
-Projects: []
+Project: []
 created: 1451590029
 ---
 

--- a/_posts/2016-01-07-a-crowd-sourced-public-transportation-map-for-managua.md
+++ b/_posts/2016-01-07-a-crowd-sourced-public-transportation-map-for-managua.md
@@ -9,7 +9,7 @@ Summary Text: There is no map for the 42 bus lines in Metropolitan Managua, capi
   they seek support (http://support.mapanica.net) to print it.
 Person: Felix Delattre
 Working Group: []
-Projects:
+Project:
 - Public transportation map for Managua
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/banner1.jpg
 created: 1452196578

--- a/_posts/2016-01-11-commence-mapping-financial-services-training.md
+++ b/_posts/2016-01-11-commence-mapping-financial-services-training.md
@@ -10,7 +10,7 @@ Summary Text: 'The Mapping Financial Inclusion in Uganda project is truly underw
   mapping the district of Mbale. '
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - Mapping Financial Inclusion in Uganda
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/training_geoffrey.jpg
 created: 1452513970

--- a/_posts/2016-01-14-jakarta-attacks-hot-indonesia-team-safe.md
+++ b/_posts/2016-01-14-jakarta-attacks-hot-indonesia-team-safe.md
@@ -4,7 +4,7 @@ date: 2016-01-14 14:47:27 Z
 permalink: updates/2016-01-14_jakarta_attacks_hot_indonesia_team_safe
 Person: Tyler Radford
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 created: 1452782847
 ---

--- a/_posts/2016-01-15-welcome-new-hot-voting-members.md
+++ b/_posts/2016-01-15-welcome-new-hot-voting-members.md
@@ -6,7 +6,7 @@ Summary Text: The Humanitarian OpenStreetMap Team is pleased to welcome eighteen
   voting members!
 Person: Russell Deffner
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/500px-Hot_logo.png
 created: 1452892985
 ---

--- a/_posts/2016-01-18-first-week-of-mapping-in-mbale-uganda.md
+++ b/_posts/2016-01-18-first-week-of-mapping-in-mbale-uganda.md
@@ -4,7 +4,7 @@ date: 2016-01-18 13:09:43 Z
 permalink: updates/2016-01-18_first_week_of_mapping_in_mbale_uganda
 Person: Paul Uithol
 Working Group: []
-Projects:
+Project:
 - Mapping Financial Inclusion in Uganda
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_20160115_105334.jpg
 created: 1453122583

--- a/_posts/2016-02-01-geo-data-collect-mobile-data-collection-and-tracking.md
+++ b/_posts/2016-02-01-geo-data-collect-mobile-data-collection-and-tracking.md
@@ -4,7 +4,7 @@ date: 2016-02-01 10:11:39 Z
 permalink: updates/2016-02-01_geo_data_collect_mobile_data_collection_and_tracking
 Person: Yantisa Akhadi
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/GeoDataCollect.PNG
 created: 1454321499

--- a/_posts/2016-02-03-my-mapping-experience-by-hillary-musundi-student-at-uganda-christian-university.md
+++ b/_posts/2016-02-03-my-mapping-experience-by-hillary-musundi-student-at-uganda-christian-university.md
@@ -11,7 +11,7 @@ Summary Text: 'When I was first told about mapping, I thought it was something t
   I felt I was ready.'
 Person: Paul Uithol
 Working Group: []
-Projects:
+Project:
 - Mapping Financial Inclusion in Uganda
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2016-02-01_IMG_20160127_113514.jpg
 created: 1454531924

--- a/_posts/2016-02-04-passengers-created-the-public-transportation-map-of-managua.md
+++ b/_posts/2016-02-04-passengers-created-the-public-transportation-map-of-managua.md
@@ -11,7 +11,7 @@ Summary Text: 'We made great progress on a crowd-sourced public transportation m
   map. And only the community made this possible:'
 Person: Felix Delattre
 Working Group: []
-Projects:
+Project:
 - Public transportation map for Managua
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_4772.JPG
 created: 1454576778

--- a/_posts/2016-02-08-the-global-footprint-of-hot.md
+++ b/_posts/2016-02-08-the-global-footprint-of-hot.md
@@ -4,7 +4,7 @@ date: 2016-02-08 20:00:13 Z
 permalink: updates/2016-02-08_the_global_footprint_of_hot
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1454961613
 ---
 

--- a/_posts/2016-02-11-osm-celebrates-international-womens-day-2016.md
+++ b/_posts/2016-02-11-osm-celebrates-international-womens-day-2016.md
@@ -5,7 +5,7 @@ permalink: updates/2016-02-11_osm_celebrates_international_women's_day_2016
 Person: Courtney Clark
 Working Group:
 - Communications
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Girl+Scouts+mapping++(1).jpg
 created: 1455206893
 ---

--- a/_posts/2016-02-16-a-day-mapping-in-dar-es-salaam-drainage-in-changombe.md
+++ b/_posts/2016-02-16-a-day-mapping-in-dar-es-salaam-drainage-in-changombe.md
@@ -13,8 +13,8 @@ Summary Text: Guest post by Kathryn Davis, Columbia University.January 14th, 10:
   side of the wide dirt road, and mark it on the map...
 Person: Paul Uithol
 Working Group: []
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Photo1_EPD+Columbia.jpg
 created: 1455659967
 ---

--- a/_posts/2016-02-19-mapping-in-mozambique-to-help-reduce-child-mortality.md
+++ b/_posts/2016-02-19-mapping-in-mozambique-to-help-reduce-child-mortality.md
@@ -4,7 +4,7 @@ date: 2016-02-19 15:38:45 Z
 permalink: updates/2016-02-19_mapping_in_mozambique_to_help_reduce_child_mortality
 Person: Blake Girardot
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/innocent-and-calist-ramani-.jpg
 created: 1455896325
 ---

--- a/_posts/2016-03-02-hot-uganda-profile-douglas-ssebaggala.md
+++ b/_posts/2016-03-02-hot-uganda-profile-douglas-ssebaggala.md
@@ -8,7 +8,7 @@ Summary Text: 'We have three Ugandan mapping supervisors on the HOT mapping team
   story and mapping history. Today, we''re speaking to Douglas.'
 Person: Paul Uithol
 Working Group: []
-Projects:
+Project:
 - Mapping Financial Inclusion in Uganda
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG-20160302-WA0000.jpg
 created: 1456934773

--- a/_posts/2016-03-07-utilizing-osm-data-for-disaster-risk-management-through-university-engagement-and-partnership.md
+++ b/_posts/2016-03-07-utilizing-osm-data-for-disaster-risk-management-through-university-engagement-and-partnership.md
@@ -11,7 +11,7 @@ Summary Text: For the past 2 years, HOT in Indonesia is implementing a universit
   program is to have disaster prone areas in Indonesia to be well mapped.
 Person: Vasanthi Hargyono
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 created: 1457322057
 ---

--- a/_posts/2016-03-09-200-kids-map-swaziland-for-malaria-elimination.md
+++ b/_posts/2016-03-09-200-kids-map-swaziland-for-malaria-elimination.md
@@ -4,7 +4,7 @@ date: 2016-03-09 08:53:20 Z
 permalink: updates/2016-03-09_200_kids_map_swaziland_for_malaria_elimination
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - Missing Maps
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/int7.jpg
 created: 1457513600

--- a/_posts/2016-03-10-osm-data-analysis-tool-development-kicks-off.md
+++ b/_posts/2016-03-10-osm-data-analysis-tool-development-kicks-off.md
@@ -4,7 +4,7 @@ date: 2016-03-10 18:05:30 Z
 permalink: updates/2016-03-10_osm_data_analysis_tool_development_kicks_off!
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - OpenStreetMap Analytics
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_20160303_125627609_HDR.jpg
 created: 1457633130

--- a/_posts/2016-03-23-hot-2016-annual-meeting-and-elections.md
+++ b/_posts/2016-03-23-hot-2016-annual-meeting-and-elections.md
@@ -9,7 +9,7 @@ Summary Text: Greetings HOT Community,Each year the Humanitarian OpenStreetMap T
   adopting or amending policies such as the Membership Code of Conduct.
 Person: Russell Deffner
 Working Group: []
-Projects: []
+Project: []
 created: 1458764399
 ---
 

--- a/_posts/2016-04-14-ramani-huria-how-are-the-maps-being-used-in-the-wards.md
+++ b/_posts/2016-04-14-ramani-huria-how-are-the-maps-being-used-in-the-wards.md
@@ -11,8 +11,8 @@ Summary Text: "(Guest post by Mercedes Hoffay, Master of Public Administration C
   Huria."
 Person: Paul Uithol
 Working Group: []
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/17639216374_f1e8eb7881_o.jpg
 created: 1460637476
 ---

--- a/_posts/2016-04-18-ambon-mapathon.md
+++ b/_posts/2016-04-18-ambon-mapathon.md
@@ -12,7 +12,7 @@ Summary Text: Ambon, located in Maluku islands which also located inside the Mol
   collection.
 Person: Vasanthi Hargyono
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Ambon+Mapathon.jpg
 created: 1461011337

--- a/_posts/2016-04-18-latest-update-earthquakes-in-japan-and-ecuador.md
+++ b/_posts/2016-04-18-latest-update-earthquakes-in-japan-and-ecuador.md
@@ -13,7 +13,7 @@ Summary Text: 'Ecuador: An earthquake of magnitude 7.8 hit the coastal region of
 Person: Tyler Radford
 Working Group:
 - Activation
-Projects:
+Project:
 - Ecuador Earthquake
 created: 1461002510
 ---

--- a/_posts/2016-04-22-ecuador-earthquake-day-7-update.md
+++ b/_posts/2016-04-22-ecuador-earthquake-day-7-update.md
@@ -5,7 +5,7 @@ permalink: updates/2016-04-22_ecuador_earthquake_day_7_update
 Person: Mhairi O'Hara
 Working Group:
 - Activation
-Projects:
+Project:
 - Ecuador Earthquake
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Capture.JPG
 created: 1461369558

--- a/_posts/2016-04-22-same-website-new-look.md
+++ b/_posts/2016-04-22-same-website-new-look.md
@@ -4,7 +4,7 @@ date: 2016-04-22 20:04:46 Z
 permalink: updates/2016-04-22_same_website_new_look!
 Person: Russell Deffner
 Working Group: []
-Projects: []
+Project: []
 created: 1461355486
 ---
 

--- a/_posts/2016-04-28-explore-how-the-world-is-mapped-with-osm-analytics.md
+++ b/_posts/2016-04-28-explore-how-the-world-is-mapped-with-osm-analytics.md
@@ -7,7 +7,7 @@ Summary Text: Today we are launching OSM Analytics, a platform for exploring and
   thousands of features added every day, OSM is officially entering the big data league.
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - OpenStreetMap Analytics
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2016-04-28+at+14.05.34.png
 created: 1461844576

--- a/_posts/2016-05-04-ecuador-earthquake-day-16-update.md
+++ b/_posts/2016-05-04-ecuador-earthquake-day-16-update.md
@@ -7,7 +7,7 @@ Summary Text: 'We want to highlight the amazing work done to date by the wonderf
   map changes with the associated #MappingEcuador changeset comment.'
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - Ecuador Earthquake
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/blog3_a.png
 created: 1462327050

--- a/_posts/2016-05-05-hot-annual-meeting-and-election-results.md
+++ b/_posts/2016-05-05-hot-annual-meeting-and-election-results.md
@@ -4,7 +4,7 @@ date: 2016-05-05 19:54:12 Z
 permalink: updates/2016-05-05_hot_annual_meeting_and_election_results
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1462478052
 ---
 

--- a/_posts/2016-05-10-mapping-the-tien-shan-mountains.md
+++ b/_posts/2016-05-10-mapping-the-tien-shan-mountains.md
@@ -11,7 +11,7 @@ Summary Text: "(Guest post by Aline Rosset, University of Central Asia) OpenStre
 Person: Felix Delattre
 Working Group:
 - Training
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/kyrgyz8.jpg
 created: 1462906687
 ---

--- a/_posts/2016-05-17-hot-summit-2016-registration-open.md
+++ b/_posts/2016-05-17-hot-summit-2016-registration-open.md
@@ -4,7 +4,7 @@ date: 2016-05-17 21:34:51 Z
 permalink: updates/2016-05-17_hot_summit_2016_-_registration_open
 Person: Cheryl Shaw
 Working Group: []
-Projects:
+Project:
 - HOT Summit 2016
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/HOT+Summit+2015.jpg
 created: 1463520891

--- a/_posts/2016-05-20-hot-at-the-world-humanitarian-summit.md
+++ b/_posts/2016-05-20-hot-at-the-world-humanitarian-summit.md
@@ -4,7 +4,7 @@ date: 2016-05-20 16:33:43 Z
 permalink: updates/2016-05-20_hot_at_the_world_humanitarian_summit
 Person: Tyler Radford
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/WHS_Logo_0_0.png
 created: 1463762023
 ---

--- a/_posts/2016-05-20-mini-mapathon-for-sri-lanka-floods-at-understanding-risk.md
+++ b/_posts/2016-05-20-mini-mapathon-for-sri-lanka-floods-at-understanding-risk.md
@@ -5,7 +5,7 @@ permalink: updates/2016-05-20_mini-mapathon_for_sri_lanka_floods_at_understandin
 Person: Heather Leson
 Working Group:
 - Activation
-Projects:
+Project:
 - Sri Lanka Flooding 2016
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Mapping+for+the+Sri+Lanka+Floods+at+Understanding+Risk+(May+2016).jpg
 created: 1463738152

--- a/_posts/2016-05-20-sri-lanka-floods-activation-sitrep-day-1.md
+++ b/_posts/2016-05-20-sri-lanka-floods-activation-sitrep-day-1.md
@@ -5,7 +5,7 @@ permalink: updates/2016-05-20_sri_lanka_floods_activation_sitrep_day_1
 Person: Blake Girardot
 Working Group:
 - Activation
-Projects:
+Project:
 - Sri Lanka Flooding 2016
 created: 1463725145
 ---

--- a/_posts/2016-05-25-new-documentation-and-design-system-for-openaerialmap.md
+++ b/_posts/2016-05-25-new-documentation-and-design-system-for-openaerialmap.md
@@ -4,7 +4,7 @@ date: 2016-05-25 09:56:17 Z
 permalink: updates/2016-05-25_new_documentation_and_design_system_for_openaerialmap
 Person: Nate Smith
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/oam-browser-post-illu-cover.png
 created: 1464170177

--- a/_posts/2016-05-27-new-project-real-time-financial-location-planning-and-research.md
+++ b/_posts/2016-05-27-new-project-real-time-financial-location-planning-and-research.md
@@ -9,7 +9,7 @@ Summary Text: Humanitarian OpenStreetMap Team (HOT) announces it is a <a href="h
   Research”.
 Person: Paul Uithol
 Working Group: []
-Projects:
+Project:
 - Mapping Financial Inclusion in Uganda
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/20160304-104825_DSCF5989.jpg
 created: 1464346196

--- a/_posts/2016-05-31-hotosm-recognized-by-the-president-of-mexico-during-internet-day-2016.md
+++ b/_posts/2016-05-31-hotosm-recognized-by-the-president-of-mexico-during-internet-day-2016.md
@@ -4,7 +4,7 @@ date: 2016-05-31 15:11:38 Z
 permalink: updates/2016-05-31_hotosm_recognized_by_the_president_of_mexico_during_internet_day_2016
 Person: Mikel Maron
 Working Group: []
-Projects:
+Project:
 - Hurricane Patricia
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Citec1kXAAIfjc5.jpg
 created: 1464707498

--- a/_posts/2016-06-03-ecuador-earthquake-assessing-the-extent-of-damaged-buildings.md
+++ b/_posts/2016-06-03-ecuador-earthquake-assessing-the-extent-of-damaged-buildings.md
@@ -8,7 +8,7 @@ Summary Text: 'Efforts are still going strong 7 weeks after the initial earthqua
   2nd stage, a pilot project aimed at mapping building damage and temporary shelters. '
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - Ecuador Earthquake
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2016-06-03+at+14.16.32.png
 created: 1464936930

--- a/_posts/2016-06-13-call-for-proposals-hot-summit-2016.md
+++ b/_posts/2016-06-13-call-for-proposals-hot-summit-2016.md
@@ -9,7 +9,7 @@ Summary Text: We invite you to submit a proposal to present a topic of interest 
   Development Goals.
 Person: Cheryl Shaw
 Working Group: []
-Projects:
+Project:
 - HOT Summit 2016
 created: 1465859514
 ---

--- a/_posts/2016-06-13-hot-and-youthmappers-collaborate-to-develop-hot-university-clubs.md
+++ b/_posts/2016-06-13-hot-and-youthmappers-collaborate-to-develop-hot-university-clubs.md
@@ -9,7 +9,7 @@ Summary Text: The Humanitarian OpenStreetMap Team (HOT) and YouthMappers share a
   for collaborating in groups around mapping projects.
 Person: Cheryl Shaw
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/6dd283_fd5593dd0aa6412fb57cd6877e9a0065.png
 created: 1465850949
 ---

--- a/_posts/2016-06-14-mapping-bicycle-routes-during-dar-es-salaams-cycle-caravan.md
+++ b/_posts/2016-06-14-mapping-bicycle-routes-during-dar-es-salaams-cycle-caravan.md
@@ -5,8 +5,8 @@ permalink: updates/2016-06-14_mapping_bicycle_routes_during_dar_es_salaam's_cycl
 Person: Innocent Maholi
 Working Group:
 - Community
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 created: 1465942633
 ---
 

--- a/_posts/2016-06-21-hot-inspires-mapping-communities-in-uganda.md
+++ b/_posts/2016-06-21-hot-inspires-mapping-communities-in-uganda.md
@@ -5,7 +5,7 @@ permalink: updates/2016-06-21_hot_inspires_mapping_communities_in_uganda
 Person: 'Douglas Ssebaggala '
 Working Group:
 - Community
-Projects:
+Project:
 - Mapping Financial Inclusion in Uganda
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/20160428_182559.jpg
 created: 1466502374

--- a/_posts/2016-06-29-hots-commitment-to-the-sustainable-development-goals-and-how-you-can-help.md
+++ b/_posts/2016-06-29-hots-commitment-to-the-sustainable-development-goals-and-how-you-can-help.md
@@ -17,7 +17,7 @@ Summary Text: 'When I speak with HOT staff and volunteers in our community, I of
   housing settlements.So what does this have to do with the SDGs?'
 Person: Tyler Radford
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Chart_of_UN_Sustainable_Development_Goals.png
 created: 1467238492
 ---

--- a/_posts/2016-07-04-using-financial-services-data-in-osm-gis-poster-and-mobile-apps.md
+++ b/_posts/2016-07-04-using-financial-services-data-in-osm-gis-poster-and-mobile-apps.md
@@ -4,7 +4,7 @@ date: 2016-07-04 11:24:16 Z
 permalink: updates/2016-07-04_using_financial_services_data_in_osm_gis_poster_and_mobile_apps
 Person: 'Douglas Ssebaggala '
 Working Group: []
-Projects:
+Project:
 - Mapping Financial Inclusion in Uganda
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Poster_winner.jpg
 created: 1467631456

--- a/_posts/2016-07-05-the-white-house-mapathon-and-hot-team-up-to-fight-malaria.md
+++ b/_posts/2016-07-05-the-white-house-mapathon-and-hot-team-up-to-fight-malaria.md
@@ -5,7 +5,7 @@ permalink: updates/2016-07-05_the_white_house_mapathon_and_hot_team_up_to_fight_
 Person: Courtney Clark
 Working Group:
 - Community
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/13580517_898774090250057_841324353105762206_o.jpg
 created: 1467752520
 ---

--- a/_posts/2016-07-21-hot-launches-new-pacdid-drone-imagery-project.md
+++ b/_posts/2016-07-21-hot-launches-new-pacdid-drone-imagery-project.md
@@ -4,7 +4,7 @@ date: 2016-07-21 01:09:37 Z
 permalink: updates/2016-07-21_hot_launches_new_pacdid_drone_imagery_project
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/PacDID-Vanuatu.jpg
 created: 1469063377

--- a/_posts/2016-07-27-introducing-the-mapillary-humanitarian-mapping-kit-in-partnership-with-hot.md
+++ b/_posts/2016-07-27-introducing-the-mapillary-humanitarian-mapping-kit-in-partnership-with-hot.md
@@ -4,7 +4,7 @@ date: 2016-07-27 14:13:45 Z
 permalink: updates/2016-07-27_introducing_the_mapillary_humanitarian_mapping_kit_in_partnership_with_hot
 Person: Tyler Radford
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2016-07-27-mapping-kit.png
 created: 1469628825
 ---

--- a/_posts/2016-07-28-new-features-for-openaerialmap.md
+++ b/_posts/2016-07-28-new-features-for-openaerialmap.md
@@ -4,7 +4,7 @@ date: 2016-07-28 05:44:51 Z
 permalink: updates/2016-07-28_new_features_for_openaerialmap
 Person: Nate Smith
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/oam-browser-post-illu-cover.png
 created: 1469684691

--- a/_posts/2016-07-30-kickoff-of-hots-participation-with-the-inaware-programme.md
+++ b/_posts/2016-07-30-kickoff-of-hots-participation-with-the-inaware-programme.md
@@ -10,7 +10,7 @@ Summary Text: 'The Humanitarian OpenStreetMap Team’s (HOT) participation in th
   Innovation (DMI), HOT and various other stakeholders. '
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - 'USAID '
 - " BNPB "
 - " InAWARE: Disaster Management Early Warning and Decision Support Capacity Enhancement

--- a/_posts/2016-08-04-mapping-the-unmapped-a-summer-fellows-foray-into-the-osm-community.md
+++ b/_posts/2016-08-04-mapping-the-unmapped-a-summer-fellows-foray-into-the-osm-community.md
@@ -5,7 +5,7 @@ permalink: updates/2016-08-04_mapping_the_unmapped__a_summer_fellows_foray_into_
 Person: 'Douglas Ssebaggala '
 Working Group:
 - Community
-Projects:
+Project:
 - Mapping Financial Inclusion in Uganda
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Gorilla+hi.png
 created: 1470305302

--- a/_posts/2016-08-09-ramani-huria-street-view-mapping-for-tanzanias-largest-city.md
+++ b/_posts/2016-08-09-ramani-huria-street-view-mapping-for-tanzanias-largest-city.md
@@ -5,8 +5,8 @@ permalink: updates/2016-08-09_ramani_huria_street_view_mapping_for_tanzania's_la
 Person: Innocent Maholi
 Working Group:
 - Community
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/20684152284_c282fe75f0_o.jpg
 created: 1470762171
 ---

--- a/_posts/2016-08-15-improving-resilience-with-aerial-imagery.md
+++ b/_posts/2016-08-15-improving-resilience-with-aerial-imagery.md
@@ -4,7 +4,7 @@ date: 2016-08-15 18:32:35 Z
 permalink: updates/2016-08-15_improving_resilience_with_aerial_imagery
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Fiji-Island.jpg
 created: 1471285955

--- a/_posts/2016-08-23-hot-joins-the-group-on-earth-observations.md
+++ b/_posts/2016-08-23-hot-joins-the-group-on-earth-observations.md
@@ -11,7 +11,7 @@ Summary Text: In July, HOT was voted in as a participating organization of the G
   HOT to contribute to use of Earth observation data and information for better decision-making.
 Person: Tyler Radford
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_7609.JPG
 created: 1471966632
 ---

--- a/_posts/2016-09-15-mapping-for-resilience-karamoja-region-uganda.md
+++ b/_posts/2016-09-15-mapping-for-resilience-karamoja-region-uganda.md
@@ -5,7 +5,7 @@ permalink: updates/2016-09-15_mapping_for_resilience_-_karamoja_region_uganda
 Person: 'Douglas Ssebaggala '
 Working Group:
 - Community
-Projects:
+Project:
 - Mapping Financial Inclusion in Uganda
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/10c518ac-197a-40c6-8e4b-0aca07b88829.jpg
 created: 1473948838

--- a/_posts/2016-09-30-hot-prepares-to-map-lifeline-infrastructure-in-surabaya.md
+++ b/_posts/2016-09-30-hot-prepares-to-map-lifeline-infrastructure-in-surabaya.md
@@ -4,7 +4,7 @@ date: 2016-09-30 05:44:33 Z
 permalink: updates/2016-09-30_hot_prepares_to_map_lifeline_infrastructure_in_surabaya
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - 'USAID '
 - " BNPB "
 - " InAWARE: Disaster Management Early Warning and Decision Support Capacity Enhancement

--- a/_posts/2016-10-04-hurricane-matthew.md
+++ b/_posts/2016-10-04-hurricane-matthew.md
@@ -5,7 +5,7 @@ permalink: updates/2016-10-04_hurricane_matthew
 Person: Dale Kunce
 Working Group:
 - Activation
-Projects:
+Project:
 - Hurricane Matthew
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/025738W5_NL_sm.gif
 created: 1475554217

--- a/_posts/2016-10-07-2015-in-review-hots-annual-report.md
+++ b/_posts/2016-10-07-2015-in-review-hots-annual-report.md
@@ -9,7 +9,7 @@ Summary Text: 'HOT''s 2015 Annual Report is now online! The report and projects 
   annual report. '
 Person: Tyler Radford
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/HOT_2015_Annual_Report.jpg
 created: 1475854121
 ---

--- a/_posts/2016-10-08-hurricane-matthew-update.md
+++ b/_posts/2016-10-08-hurricane-matthew-update.md
@@ -5,7 +5,7 @@ permalink: updates/2016-10-08_hurricane_matthew_update
 Person: Dale Kunce
 Working Group:
 - Activation
-Projects:
+Project:
 - Hurricane Matthew
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/30144517616_fe5c10a6bf_k.jpg
 created: 1475904963

--- a/_posts/2016-10-18-work-for-hot-open-job-opportunities.md
+++ b/_posts/2016-10-18-work-for-hot-open-job-opportunities.md
@@ -8,7 +8,7 @@ Summary Text: 'HOT welcomes qualified applicants to apply to work with us! There
   Manager Re-DesignDeadline Oct 31: System Administrator/DevOps Engineer (Part-time)'
 Person: Tyler Radford
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/DSC_0186a.jpg
 created: 1476820714
 ---

--- a/_posts/2016-10-19-help-disaster-management-in-surabaya-by-mapping-remotely.md
+++ b/_posts/2016-10-19-help-disaster-management-in-surabaya-by-mapping-remotely.md
@@ -4,7 +4,7 @@ date: 2016-10-19 03:21:38 Z
 permalink: updates/2016-10-19_help_disaster_management_in_surabaya_by_mapping_remotely_
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - 'USAID '
 - " BNPB "
 - " InAWARE: Disaster Management Early Warning and Decision Support Capacity Enhancement

--- a/_posts/2016-10-19-mapping-dar-es-salaams-water-sanitation-and-hygiene-facilities.md
+++ b/_posts/2016-10-19-mapping-dar-es-salaams-water-sanitation-and-hygiene-facilities.md
@@ -5,8 +5,8 @@ permalink: updates/2016-10-19_mapping_dar_es_salaam's_water_sanitation_and_hygie
 Person: Innocent Maholi
 Working Group:
 - Community
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2.jpg
 created: 1476887368
 ---

--- a/_posts/2016-10-25-osm-geoweek-is-november-13th-19th-host-a-mapping-event.md
+++ b/_posts/2016-10-25-osm-geoweek-is-november-13th-19th-host-a-mapping-event.md
@@ -4,7 +4,7 @@ date: 2016-10-25 15:53:49 Z
 permalink: updates/2016-10-25_osm_geoweek_is_november_13th-19th_host_a_mapping_event!
 Person: Tyler Radford
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/MapOff_GWU.jpg
 created: 1477410829
 ---

--- a/_posts/2016-10-28-missed-the-hot-summit-watch-it-online.md
+++ b/_posts/2016-10-28-missed-the-hot-summit-watch-it-online.md
@@ -4,7 +4,7 @@ date: 2016-10-28 23:19:31 Z
 permalink: updates/2016-10-28_missed_the_hot_summit?_watch_it_online!
 Person: Tyler Radford
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/hot-summit-group-wave+(2).JPG
 created: 1477696771
 ---

--- a/_posts/2016-11-11-collaborating-with-university-students-hot-hosts-a-mapathon-at-the-institut-teknologi-sepuluh-nopemb.md
+++ b/_posts/2016-11-11-collaborating-with-university-students-hot-hosts-a-mapathon-at-the-institut-teknologi-sepuluh-nopemb.md
@@ -5,7 +5,7 @@ date: 2016-11-11 09:32:46 Z
 permalink: updates/2016-11-11_collaborating_with_university_students_hot_hosts_a_mapathon_at_the_institut_tekn
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - 'USAID '
 - " BNPB "
 - " InAWARE: Disaster Management Early Warning and Decision Support Capacity Enhancement

--- a/_posts/2016-11-15-analyzing-openstreetmap-for-the-fight-against-malaria.md
+++ b/_posts/2016-11-15-analyzing-openstreetmap-for-the-fight-against-malaria.md
@@ -4,7 +4,7 @@ date: 2016-11-15 12:31:08 Z
 permalink: updates/2016-11-15_analyzing_openstreetmap_for_the_fight_against_malaria
 Person: Nate Smith
 Working Group: []
-Projects:
+Project:
 - OpenStreetMap Analytics
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2016-11-15+at+12.46.12+PM+copy.png
 created: 1479213068

--- a/_posts/2016-11-21-ramani-huria-closing-workshop-reflection-and-new-direction.md
+++ b/_posts/2016-11-21-ramani-huria-closing-workshop-reflection-and-new-direction.md
@@ -5,8 +5,8 @@ permalink: updates/2016-11-21_ramani_huria_closing_workshop_reflection_&_new_dir
 Person: Innocent Maholi
 Working Group:
 - Community
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_9878+-+1.jpg
 created: 1479725441
 ---

--- a/_posts/2016-11-23-supporting-humanitarian-response-with-better-imagery-coordination.md
+++ b/_posts/2016-11-23-supporting-humanitarian-response-with-better-imagery-coordination.md
@@ -4,7 +4,7 @@ date: 2016-11-23 21:53:28 Z
 permalink: updates/2016-11-23_supporting_humanitarian_response_with_better_imagery_coordination
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/imagery-coord-wireframes-compressor+copy.png
 created: 1479938008

--- a/_posts/2016-11-24-boosting-spatial-data-awareness-and-participation-hot-indonesia-hosts-osmgeoweek-talkshow.md
+++ b/_posts/2016-11-24-boosting-spatial-data-awareness-and-participation-hot-indonesia-hosts-osmgeoweek-talkshow.md
@@ -5,7 +5,7 @@ date: 2016-11-24 06:42:07 Z
 permalink: updates/2016-11-24_boosting_spatial_data_awareness_and_participation_hot_indonesia_hosts_osmgeoweek
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/15195813_1667479563544092_5619402404480047323_o.jpg
 created: 1479969727

--- a/_posts/2016-11-28-mapping-the-worlds-vulnerable-places-begins-with-you.md
+++ b/_posts/2016-11-28-mapping-the-worlds-vulnerable-places-begins-with-you.md
@@ -8,7 +8,7 @@ Summary Text: Help HOT provide 10 communities with equipment and funding to map!
   first time. You can show your support by making a donation today.
 Person: Tyler Radford
 Working Group: []
-Projects:
+Project:
 - Mapping the world’s vulnerable places begins with you!
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/video+screenshot.PNG
 created: 1480371725

--- a/_posts/2016-12-01-hots-osm-tasking-manager-3-0-development-kick-off.md
+++ b/_posts/2016-12-01-hots-osm-tasking-manager-3-0-development-kick-off.md
@@ -5,7 +5,7 @@ permalink: updates/2016-12-01_hot's_osm_tasking_manager_30_development_kick-off!
 Person: Blake Girardot
 Working Group:
 - Training
-Projects:
+Project:
 - OSM Tasking Manager 3.0 Development
 created: 1480633379
 ---

--- a/_posts/2016-12-01-hots-osm-tasking-manager-3-0-tech-challenge.md
+++ b/_posts/2016-12-01-hots-osm-tasking-manager-3-0-tech-challenge.md
@@ -7,7 +7,7 @@ Summary Text: Humanitarian OpenStreetMap Team (HOT) is seeking proposals for the
 Person: Blake Girardot
 Working Group:
 - Training
-Projects:
+Project:
 - OSM Tasking Manager 3.0 Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2016-12-01_14h49_35.png
 created: 1480618733

--- a/_posts/2016-12-06-funds-for-community-led-projects-the-2017-hot-microgrants-program.md
+++ b/_posts/2016-12-06-funds-for-community-led-projects-the-2017-hot-microgrants-program.md
@@ -4,7 +4,7 @@ date: 2016-12-06 22:02:37 Z
 permalink: updates/2016-12-06_funds_for_community-led_projects_the_2017_hot_microgrants_program
 Person: Tyler Radford
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2017+microgrants.png
 created: 1481061757
 ---

--- a/_posts/2016-12-13-hot-indonesia-launches-a-tasking-manager-and-pidie-mapathon-in-response-to-aceh-earthquake.md
+++ b/_posts/2016-12-13-hot-indonesia-launches-a-tasking-manager-and-pidie-mapathon-in-response-to-aceh-earthquake.md
@@ -5,7 +5,7 @@ date: 2016-12-13 09:59:36 Z
 permalink: updates/2016-12-13_hot_indonesia_launches_a_tasking_manager_and_pidie_mapathon_in_response_to_aceh_
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Pidie+Mapathon+final.001.jpeg
 created: 1481623176

--- a/_posts/2016-12-16-openstreetmap-workshop-at-the-pacific-gis-and-remote-sensing-conference-university-of-the-south-paci.md
+++ b/_posts/2016-12-16-openstreetmap-workshop-at-the-pacific-gis-and-remote-sensing-conference-university-of-the-south-paci.md
@@ -5,7 +5,7 @@ date: 2016-12-16 13:03:30 Z
 permalink: updates/2016-12-16_openstreetmap_workshop_at_the_pacific_gis_and_remote_sensing_conference_(univers
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2016-12-17+at+02.57.57.png
 created: 1481893410

--- a/_posts/2016-12-20-making-use-cases-for-crowd-sourced-financial-services-data-in-uganda.md
+++ b/_posts/2016-12-20-making-use-cases-for-crowd-sourced-financial-services-data-in-uganda.md
@@ -5,7 +5,7 @@ permalink: updates/2016-12-20_making_use_cases_for_crowd_sourced_financial_servi
 Person: 'Douglas Ssebaggala '
 Working Group:
 - Community
-Projects:
+Project:
 - Mapping Financial Inclusion in Uganda
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/20161206_121846.jpg
 created: 1482235628

--- a/_posts/2017-01-26-help-translate-training-videos.md
+++ b/_posts/2017-01-26-help-translate-training-videos.md
@@ -5,7 +5,7 @@ permalink: updates/2017-01-26_help_translate_training_videos
 Person: Dale Kunce
 Working Group:
 - Training
-Projects:
+Project:
 - Missing Maps
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-01-25+at+8.11.04+PM.png
 created: 1485404031

--- a/_posts/2017-01-26-ramani-huria-trains-secondary-school-students-during-stem-boot-camp.md
+++ b/_posts/2017-01-26-ramani-huria-trains-secondary-school-students-during-stem-boot-camp.md
@@ -5,8 +5,8 @@ permalink: updates/2017-01-26_ramani_huria_trains_secondary_school_students_duri
 Person: Innocent Maholi
 Working Group:
 - Community
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/15941302_1911596629070902_2449297582192792374_n.jpg
 created: 1485417473
 ---

--- a/_posts/2017-01-27-learning-from-hot-indonesia.md
+++ b/_posts/2017-01-27-learning-from-hot-indonesia.md
@@ -5,7 +5,7 @@ permalink: updates/2017-01-27_learning_from_hot_indonesia
 Person: Geoffrey Kateregga
 Working Group:
 - Community
-Projects:
+Project:
 - 'USAID '
 - " BNPB "
 - " InAWARE: Disaster Management Early Warning and Decision Support Capacity Enhancement

--- a/_posts/2017-01-27-recap-of-the-un-world-data-forum-using-openstreetmap-for-the-sustainable-development-goals.md
+++ b/_posts/2017-01-27-recap-of-the-un-world-data-forum-using-openstreetmap-for-the-sustainable-development-goals.md
@@ -5,7 +5,7 @@ date: 2017-01-27 11:03:21 Z
 permalink: updates/2017-01-27_recap_of_the_un_world_data_forum_using_openstreetmap_for_the_sustainable_develop
 Person: Rebecca Firth
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-01-27+at+14.35.39.png
 created: 1485515001
 ---

--- a/_posts/2017-01-31-making-open-imagery-accessible-openaerialmap-comes-out-of-beta.md
+++ b/_posts/2017-01-31-making-open-imagery-accessible-openaerialmap-comes-out-of-beta.md
@@ -4,7 +4,7 @@ date: 2017-01-31 13:33:57 Z
 permalink: updates/2017-01-31_making_open_imagery_accessible_openaerialmap_comes_out_of_beta
 Person: Nate Smith
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/oam-malawi.jpg
 created: 1485869637

--- a/_posts/2017-02-02-hot-microgrants-programme-launches.md
+++ b/_posts/2017-02-02-hot-microgrants-programme-launches.md
@@ -5,7 +5,7 @@ permalink: updates/2017-02-02_hot_microgrants_programme_launches
 Person: Rebecca Firth
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2017+microgrants_0.png
 created: 1486053007

--- a/_posts/2017-02-06-kicking-off-the-crowdsourcing-non-camp-refugee-data-project.md
+++ b/_posts/2017-02-06-kicking-off-the-crowdsourcing-non-camp-refugee-data-project.md
@@ -4,7 +4,7 @@ date: 2017-02-06 15:24:17 Z
 permalink: updates/2017-02-06_kicking_off_the_“crowdsourcing_non-camp_refugee_data”_project
 Person: Paul Uithol
 Working Group: []
-Projects:
+Project:
 - 'Urban Innovations: Crowdsourcing Non-Camp Refugee Data'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2017-01_SSudan_Refugee_Mothers_Blog_760x428_3.jpg
 created: 1486394657

--- a/_posts/2017-02-13-growing-openaerialmap-with-responsible-imagery.md
+++ b/_posts/2017-02-13-growing-openaerialmap-with-responsible-imagery.md
@@ -4,7 +4,7 @@ date: 2017-02-13 10:46:38 Z
 permalink: updates/2017-02-13_growing_openaerialmap_with_responsible_imagery
 Person: Nate Smith
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen-Shot-2017-02-13-at-1.00.49-PM-compressor.png
 created: 1486982798

--- a/_posts/2017-02-17-2016-hot-by-the-numbers.md
+++ b/_posts/2017-02-17-2016-hot-by-the-numbers.md
@@ -7,7 +7,7 @@ Summary Text: We've put together some of the 2016 highlights so you can see what
 Person: Rachel VanNice
 Working Group:
 - Communications
-Projects: []
+Project: []
 created: 1487311200
 ---
 

--- a/_posts/2017-02-20-hot-concludes-city-wide-mapping-project-in-surabaya-key-results-and-lessons-learned.md
+++ b/_posts/2017-02-20-hot-concludes-city-wide-mapping-project-in-surabaya-key-results-and-lessons-learned.md
@@ -5,7 +5,7 @@ date: 2017-02-20 09:09:36 Z
 permalink: updates/2017-02-20_hot_concludes_city-wide_mapping_project_in_surabaya_key_results_and_lessons’_l
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - 'USAID '
 - " BNPB "
 - " InAWARE: Disaster Management Early Warning and Decision Support Capacity Enhancement

--- a/_posts/2017-02-21-2017-microgrants-programme-in-full-swing-read-our-q-and-a-summary.md
+++ b/_posts/2017-02-21-2017-microgrants-programme-in-full-swing-read-our-q-and-a-summary.md
@@ -4,7 +4,7 @@ date: 2017-02-21 19:07:16 Z
 permalink: updates/2017-02-21_2017_microgrants_programme_in_full_swing_-_read_our_q&a_summary
 Person: Rebecca Firth
 Working Group: []
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2017+microgrants_0.png
 created: 1487704036

--- a/_posts/2017-02-28-why-women-in-mapping-matters-mapping-for-women-and-girls.md
+++ b/_posts/2017-02-28-why-women-in-mapping-matters-mapping-for-women-and-girls.md
@@ -4,7 +4,7 @@ date: 2017-02-28 19:46:50 Z
 permalink: updates/2017-02-28_why_women_in_mapping_matters_-_mapping_for_women_and_girls
 Person: Gertrude (Trudy Hope) Namitala
 Working Group: []
-Projects:
+Project:
 - Women and Girls in Mapping
 created: 1488311210
 ---

--- a/_posts/2017-03-01-hot-board-and-chair-elections.md
+++ b/_posts/2017-03-01-hot-board-and-chair-elections.md
@@ -4,7 +4,7 @@ date: 2017-03-01 19:48:55 Z
 permalink: updates/2017-03-01_hot_board_and_chair_elections
 Person: Mikel Maron
 Working Group: []
-Projects: []
+Project: []
 created: 1488397735
 ---
 

--- a/_posts/2017-03-06-malaria-mapping-youthmappers-challenge.md
+++ b/_posts/2017-03-06-malaria-mapping-youthmappers-challenge.md
@@ -11,7 +11,7 @@ Summary Text: HOT is managing a mapping project for malaria eradication across s
   to the chapters that contribute the most quality data to this project.
 Person: Russell Deffner
 Working Group: []
-Projects:
+Project:
 - Malaria Elimination Campaign
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/YM-HIRES-banner.jpg
 created: 1488815367

--- a/_posts/2017-03-06-osm-tasking-manager-3-project-update-1.md
+++ b/_posts/2017-03-06-osm-tasking-manager-3-project-update-1.md
@@ -4,7 +4,7 @@ date: 2017-03-06 16:25:29 Z
 permalink: updates/2017-03-06_osm_tasking_manager_3_project_update_#1
 Person: Blake Girardot
 Working Group: []
-Projects:
+Project:
 - OSM Tasking Manager 3.0 Development
 created: 1488817529
 ---

--- a/_posts/2017-03-07-this-international-womens-day-show-your-support-by-mapping.md
+++ b/_posts/2017-03-07-this-international-womens-day-show-your-support-by-mapping.md
@@ -5,7 +5,7 @@ permalink: updates/2017-03-07_this_international_women’s_day_show_your_support
 Person: Rebecca Firth
 Working Group:
 - Communications
-Projects:
+Project:
 - Women and Girls in Mapping
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-03-06+at+21.58.01.png
 created: 1488854820

--- a/_posts/2017-03-13-celebrating-international-womens-day-hot-empowers-women-with-ict-and-mapping-skills.md
+++ b/_posts/2017-03-13-celebrating-international-womens-day-hot-empowers-women-with-ict-and-mapping-skills.md
@@ -5,7 +5,7 @@ date: 2017-03-13 09:19:04 Z
 permalink: updates/2017-03-13_celebrating_international_women’s_day_hot_empowers_women_with_ict_and_mapping_
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-03-10+at+12.07.21+PM.png
 created: 1489396744

--- a/_posts/2017-03-13-mapping-for-government-inclusion-and-service-delivery-in-liberia.md
+++ b/_posts/2017-03-13-mapping-for-government-inclusion-and-service-delivery-in-liberia.md
@@ -4,7 +4,7 @@ date: 2017-03-13 03:51:49 Z
 permalink: updates/2017-03-13_mapping_for_government_inclusion_and_service_delivery_in_liberia
 Person: David Luswata
 Working Group: []
-Projects:
+Project:
 - 'LEGIT: Supporting decentralization in Liberian cities'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_20170220_122606.jpg
 created: 1489377109

--- a/_posts/2017-03-15-imagery-released-for-cyclone-enawo-to-support-mapping-activities.md
+++ b/_posts/2017-03-15-imagery-released-for-cyclone-enawo-to-support-mapping-activities.md
@@ -4,7 +4,7 @@ date: 2017-03-15 13:59:24 Z
 permalink: updates/2017-03-15_imagery_released_for_cyclone_enawo_to_support_mapping_activities
 Person: Nate Smith
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-03-15+at+12.08.37+PM.png
 created: 1489586364
 ---

--- a/_posts/2017-03-17-next-generation-hot-export-tool-version-3.md
+++ b/_posts/2017-03-17-next-generation-hot-export-tool-version-3.md
@@ -12,7 +12,7 @@ Summary Text: The HOT Export Tool allows users to create custom OpenStreetMap (O
   its performance.
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - 'USAID '
 - " BNPB "
 - " InAWARE: Disaster Management Early Warning and Decision Support Capacity Enhancement

--- a/_posts/2017-03-22-how-youth-mappers-in-uganda-are-improving-their-mapping-skills-through-mapping-with-hot-for-malaria-.md
+++ b/_posts/2017-03-22-how-youth-mappers-in-uganda-are-improving-their-mapping-skills-through-mapping-with-hot-for-malaria-.md
@@ -6,7 +6,7 @@ permalink: updates/2017-03-22_how_youth_mappers_in_uganda_are_improving_their_ma
 Person: Geoffrey Kateregga
 Working Group:
 - Community
-Projects:
+Project:
 - Malaria Elimination Campaign
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/makerere.jpg
 created: 1490168878

--- a/_posts/2017-04-03-uploading-made-easier-new-options-available-for-openaerialmap.md
+++ b/_posts/2017-04-03-uploading-made-easier-new-options-available-for-openaerialmap.md
@@ -4,7 +4,7 @@ date: 2017-04-03 17:18:39 Z
 permalink: updates/2017-04-03_uploading_made_easier_new_options_available_for_openaerialmap
 Person: Nate Smith
 Working Group: []
-Projects:
+Project:
 - OpenAerialMap
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-04-03+at+6.02.53+PM.png
 created: 1491239919

--- a/_posts/2017-04-07-world-health-day-2017-show-your-support-by-mapping-for-malaria.md
+++ b/_posts/2017-04-07-world-health-day-2017-show-your-support-by-mapping-for-malaria.md
@@ -12,7 +12,7 @@ Summary Text: Malaria is a disease that affects millions of people around the wo
   insecticide or distribute bednets. This way you can save more lives, more quickly.
 Person: Russell Deffner
 Working Group: []
-Projects:
+Project:
 - Malaria Elimination Campaign
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/29698512922_8315698194_b.jpg
 created: 1491591649

--- a/_posts/2017-04-12-youthmappers-mapping-to-end-malaria-challenge-round-1-results.md
+++ b/_posts/2017-04-12-youthmappers-mapping-to-end-malaria-challenge-round-1-results.md
@@ -7,7 +7,7 @@ Summary Text: Our first round of the YouthMappers ‘Mapping to end Malaria’ C
   in Zambia and Zimbabwe. Thank you to all the chapters who participated!
 Person: Russell Deffner
 Working Group: []
-Projects:
+Project:
 - Malaria Elimination Campaign
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/udea+177.JPG
 created: 1492039935

--- a/_posts/2017-04-14-welcome-hots-new-board-members.md
+++ b/_posts/2017-04-14-welcome-hots-new-board-members.md
@@ -4,7 +4,7 @@ date: 2017-04-14 23:42:22 Z
 permalink: updates/2017-04-14_welcome_hot's_new_board_members!_
 Person: Rachel VanNice
 Working Group: []
-Projects: []
+Project: []
 created: 1492213342
 ---
 

--- a/_posts/2017-04-20-hot-microgrants-2017-results.md
+++ b/_posts/2017-04-20-hot-microgrants-2017-results.md
@@ -5,7 +5,7 @@ permalink: updates/2017-04-20_hot_microgrants_2017_results
 Person: Rebecca Firth
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2017+microgrants_0.png
 created: 1492708088

--- a/_posts/2017-04-21-world-malaria-day-map-to-help-malaria-elimination-worldwide.md
+++ b/_posts/2017-04-21-world-malaria-day-map-to-help-malaria-elimination-worldwide.md
@@ -4,7 +4,7 @@ date: 2017-04-21 16:06:41 Z
 permalink: updates/2017-04-21_world_malaria_day_map_to_help_malaria_elimination_worldwide
 Person: Rebecca Firth
 Working Group: []
-Projects:
+Project:
 - Malaria Elimination Campaign
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2017-04-21.png
 created: 1492790801

--- a/_posts/2017-04-25-paving-the-road-to-inclusivity-hot-trains-mapping-skills-to-disabled-communities.md
+++ b/_posts/2017-04-25-paving-the-road-to-inclusivity-hot-trains-mapping-skills-to-disabled-communities.md
@@ -4,7 +4,7 @@ date: 2017-04-25 08:35:39 Z
 permalink: updates/2017-04-25_paving_the_road_to_inclusivity_hot_trains_mapping_skills_to_disabled_communities
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-04-25+at+3.31.37+PM.png
 created: 1493109339

--- a/_posts/2017-04-26-hot-research-partnership-on-crowdsourced-damage-assessment.md
+++ b/_posts/2017-04-26-hot-research-partnership-on-crowdsourced-damage-assessment.md
@@ -4,7 +4,7 @@ date: 2017-04-26 17:28:17 Z
 permalink: updates/2017-04-26_hot_research_partnership_on_crowdsourced_damage_assessment
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - Remote Damage Assessment Research
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/S_header.jpg
 created: 1493227697

--- a/_posts/2017-04-27-branching-out-manpower-to-mapping-136-priority-areas-in-indonesia-through-training-of-trainers-tot.md
+++ b/_posts/2017-04-27-branching-out-manpower-to-mapping-136-priority-areas-in-indonesia-through-training-of-trainers-tot.md
@@ -10,7 +10,7 @@ Summary Text: As we wrote earlier, Indonesia’s disaster management agency is t
   one.
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/17879888_1728450020780379_3811758073513746730_o.jpg
 created: 1493281790

--- a/_posts/2017-04-29-cyclone-enawo-response-madagascar.md
+++ b/_posts/2017-04-29-cyclone-enawo-response-madagascar.md
@@ -5,7 +5,7 @@ permalink: updates/2017-04-29_cyclone_enawo_response_-_madagascar_
 Person: Matthew Gibb
 Working Group:
 - Activation
-Projects:
+Project:
 - Cyclone Enawo Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/maroantsetra_buildings_lowres.png
 created: 1493429254

--- a/_posts/2017-05-03-rapid-mapping-of-damage-extent-after-a-disaster.md
+++ b/_posts/2017-05-03-rapid-mapping-of-damage-extent-after-a-disaster.md
@@ -4,7 +4,7 @@ date: 2017-05-03 06:06:41 Z
 permalink: updates/2017-05-03_rapid_mapping_of_damage_extent_after_a_disaster
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - Remote Damage Assessment Research
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/PicturePileHeader.jpg
 created: 1493791601

--- a/_posts/2017-05-05-gulu-mapathon-and-partnerships.md
+++ b/_posts/2017-05-05-gulu-mapathon-and-partnerships.md
@@ -5,7 +5,7 @@ permalink: updates/2017-05-05_gulu_mapathon_and_partnerships
 Person: 'Douglas Ssebaggala '
 Working Group:
 - Community
-Projects:
+Project:
 - 'Urban Innovations: Crowdsourcing Non-Camp Refugee Data'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/20170407_090235.jpg
 created: 1493944391

--- a/_posts/2017-05-08-2017-hot-board-roles.md
+++ b/_posts/2017-05-08-2017-hot-board-roles.md
@@ -4,7 +4,7 @@ date: 2017-05-08 16:49:58 Z
 permalink: updates/2017-05-08_2017_hot_board_roles_
 Person: Rachel VanNice
 Working Group: []
-Projects: []
+Project: []
 created: 1494262198
 ---
 

--- a/_posts/2017-05-08-youthmappers-mapping-to-end-malaria-challenge-round-2-results.md
+++ b/_posts/2017-05-08-youthmappers-mapping-to-end-malaria-challenge-round-2-results.md
@@ -7,7 +7,7 @@ Summary Text: Over 200 students at 13 universities participated in the second ro
   400,000 buildings in Zimbabwe. Thank you to all the chapters who participated!
 Person: Russell Deffner
 Working Group: []
-Projects:
+Project:
 - Malaria Elimination Campaign
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/UCC+YM.jpg
 created: 1494254400

--- a/_posts/2017-05-19-5600000-map-edits-to-eliminate-malaria.md
+++ b/_posts/2017-05-19-5600000-map-edits-to-eliminate-malaria.md
@@ -5,7 +5,7 @@ permalink: updates/2017-05-19_5600000_map_edits_to_eliminate_malaria
 Person: Geoffrey Kateregga
 Working Group:
 - Community
-Projects:
+Project:
 - Malaria Elimination Campaign
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/busitema.jpg
 created: 1495176666

--- a/_posts/2017-05-19-openstreetmap-on-the-humanitarian-data-exchange.md
+++ b/_posts/2017-05-19-openstreetmap-on-the-humanitarian-data-exchange.md
@@ -10,7 +10,7 @@ Summary Text: The Export Tool is now pushing customised OpenStreetMap (OSM) data
   and allows the administrators to select any country for export.
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - 'Export Tool 3.0 '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-05-19+at+14.23.46.png
 created: 1495173448

--- a/_posts/2017-05-22-inaware-mapping-project-moves-from-surabaya-to-jakarta.md
+++ b/_posts/2017-05-22-inaware-mapping-project-moves-from-surabaya-to-jakarta.md
@@ -4,7 +4,7 @@ date: 2017-05-22 10:02:25 Z
 permalink: updates/2017-05-22_inaware_mapping_project_moves_from_surabaya_to_jakarta
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - 'USAID '
 - " BNPB "
 - " InAWARE: Disaster Management Early Warning and Decision Support Capacity Enhancement

--- a/_posts/2017-05-24-organized-distributed-openstreetmap-field-mapping.md
+++ b/_posts/2017-05-24-organized-distributed-openstreetmap-field-mapping.md
@@ -4,7 +4,7 @@ date: 2017-05-24 14:34:59 Z
 permalink: updates/2017-05-24_organized_distributed_openstreetmap_field_mapping
 Person: Nate Smith
 Working Group: []
-Projects:
+Project:
 - 'Urban Innovations: Crowdsourcing Non-Camp Refugee Data'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/DSCF5987-compressor.jpg
 created: 1495636499

--- a/_posts/2017-05-25-legit-kicks-off-field-mapping-with-training-in-monrovia.md
+++ b/_posts/2017-05-25-legit-kicks-off-field-mapping-with-training-in-monrovia.md
@@ -4,7 +4,7 @@ date: 2017-05-25 12:29:56 Z
 permalink: updates/2017-05-25_legit_kicks_off_field_mapping_with_training_in_monrovia
 Person: David Luswata
 Working Group: []
-Projects:
+Project:
 - 'LEGIT: Supporting decentralization in Liberian cities'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/monrovia_training.jpg
 created: 1495715396

--- a/_posts/2017-06-05-legit-team-completes-field-mapping-in-zwedru-city.md
+++ b/_posts/2017-06-05-legit-team-completes-field-mapping-in-zwedru-city.md
@@ -4,7 +4,7 @@ date: 2017-06-05 15:26:09 Z
 permalink: updates/2017-06-05_legit_team_completes_field_mapping_in_zwedru_city
 Person: David Luswata
 Working Group: []
-Projects:
+Project:
 - 'LEGIT: Supporting decentralization in Liberian cities'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Boundary_comparison_1.png
 created: 1496676369

--- a/_posts/2017-06-07-open-global-exposure-database-for-multi-hazard-risk.md
+++ b/_posts/2017-06-07-open-global-exposure-database-for-multi-hazard-risk.md
@@ -10,7 +10,7 @@ Summary Text: The Humanitarian OpenStreetMap Team has partnered with the Global 
   through innovation in order to better identify risk and enable more effective decision-making.
 Person: Mhairi O'Hara
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/GED4ALL+-+Project+Overview.png
 created: 1496866519
 ---

--- a/_posts/2017-06-09-collaborating-with-iom-the-un-migration-agency-on-openstreetmap.md
+++ b/_posts/2017-06-09-collaborating-with-iom-the-un-migration-agency-on-openstreetmap.md
@@ -4,7 +4,7 @@ date: 2017-06-09 11:12:52 Z
 permalink: updates/2017-06-09_collaborating_with_iom_the_un_migration_agency_on_openstreetmap
 Person: Nate Smith
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/AX3A9733+(2).jpg
 created: 1497006772
 ---

--- a/_posts/2017-06-12-youthmappers-mapping-to-end-malaria-challenge-round-3-results.md
+++ b/_posts/2017-06-12-youthmappers-mapping-to-end-malaria-challenge-round-3-results.md
@@ -5,7 +5,7 @@ permalink: updates/2017-06-12_youthmappers_‘mapping_to_end_malaria’_challeng
 Person: Russell Deffner
 Working Group:
 - Community
-Projects:
+Project:
 - Malaria Elimination Campaign
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/20170506_173519.jpg
 created: 1497234339

--- a/_posts/2017-06-15-hot-indonesia-hosts-mapathon-for-inaware-jakarta-mapping-project-with-the-university-of-indonesia.md
+++ b/_posts/2017-06-15-hot-indonesia-hosts-mapathon-for-inaware-jakarta-mapping-project-with-the-university-of-indonesia.md
@@ -5,7 +5,7 @@ date: 2017-06-15 04:12:26 Z
 permalink: updates/2017-06-15_hot_indonesia_hosts_mapathon_for_inaware_jakarta_mapping_project_with__the_unive
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - 'USAID '
 - " BNPB "
 - " InAWARE: Disaster Management Early Warning and Decision Support Capacity Enhancement

--- a/_posts/2017-06-28-call-for-participation-crowdsourced-damage-assessment.md
+++ b/_posts/2017-06-28-call-for-participation-crowdsourced-damage-assessment.md
@@ -4,7 +4,7 @@ date: 2017-06-28 06:11:15 Z
 permalink: updates/2017-06-28_call_for_participation_crowdsourced_damage_assessment
 Person: Cristiano Giovando
 Working Group: []
-Projects:
+Project:
 - Remote Damage Assessment Research
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-06-27+at+22.57.42.jpg
 created: 1498630275

--- a/_posts/2017-07-03-volunteers-in-uganda-and-turkey-rally-to-support-refugees-on-world-refugee-day.md
+++ b/_posts/2017-07-03-volunteers-in-uganda-and-turkey-rally-to-support-refugees-on-world-refugee-day.md
@@ -5,7 +5,7 @@ date: 2017-07-03 08:53:14 Z
 permalink: updates/2017-07-03_volunteers_in_uganda_and_turkey_rally_to_support_refugees_on_world_refugee_day
 Person: Geoffrey Kateregga
 Working Group: []
-Projects:
+Project:
 - 'Urban Innovations: Crowdsourcing Non-Camp Refugee Data'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/image5.jpg
 created: 1499071994

--- a/_posts/2017-07-06-bringing-remote-mapping-to-the-field.md
+++ b/_posts/2017-07-06-bringing-remote-mapping-to-the-field.md
@@ -5,7 +5,7 @@ permalink: updates/2017-07-06_bringing_remote_mapping_to_the_field
 Person: 'Douglas Ssebaggala '
 Working Group:
 - Community
-Projects:
+Project:
 - 'Urban Innovations: Crowdsourcing Non-Camp Refugee Data'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/20170622_110950_data+col.jpg
 created: 1499330505

--- a/_posts/2017-07-10-hot-supports-community-driven-open-data-ger-community-mapping-center-mongolia.md
+++ b/_posts/2017-07-10-hot-supports-community-driven-open-data-ger-community-mapping-center-mongolia.md
@@ -5,7 +5,7 @@ permalink: updates/2017-07-10_hot_supports_community_driven_open_data_ger_commun
 Person: Rebecca Firth
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Ger2.png
 created: 1499712786

--- a/_posts/2017-07-17-state-of-the-map-africa-the-first-conference.md
+++ b/_posts/2017-07-17-state-of-the-map-africa-the-first-conference.md
@@ -5,7 +5,7 @@ permalink: updates/2017-07-17_state_of_the_map_africa_the_first_conference
 Person: Rebecca Firth
 Working Group:
 - Community
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/SOTMAfrica.jpg
 created: 1500328052
 ---

--- a/_posts/2017-07-18-three-hundred-students-to-map-for-flood-resilience-in-dar-es-salaam.md
+++ b/_posts/2017-07-18-three-hundred-students-to-map-for-flood-resilience-in-dar-es-salaam.md
@@ -5,8 +5,8 @@ permalink: updates/2017-07-18_three_hundred_students_to_map_for_flood_resilience
 Person: Innocent Maholi
 Working Group:
 - Community
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/innocent.jpg
 created: 1500411600
 ---

--- a/_posts/2017-07-20-from-the-map-to-the-field-hot-trains-msf-and-refugees-in-field-data-collection-uganda.md
+++ b/_posts/2017-07-20-from-the-map-to-the-field-hot-trains-msf-and-refugees-in-field-data-collection-uganda.md
@@ -6,7 +6,7 @@ permalink: updates/2017-07-20_from_the_map_to_the_field_hot_trains_msf_and_refug
 Person: 'Douglas Ssebaggala '
 Working Group:
 - Community
-Projects:
+Project:
 - 'Urban Innovations: Crowdsourcing Non-Camp Refugee Data'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Field_Mapathon.jpg
 created: 1500559854

--- a/_posts/2017-08-03-crowd2map-tanzania-putting-rural-tanzania-on-the-map-with-the-help-of-a-hot-microgrant.md
+++ b/_posts/2017-08-03-crowd2map-tanzania-putting-rural-tanzania-on-the-map-with-the-help-of-a-hot-microgrant.md
@@ -5,7 +5,7 @@ date: 2017-08-03 02:31:49 Z
 permalink: updates/2017-08-03_crowd2map_tanzania_putting_rural_tanzania_on_the_map_with_the_help_of_a_hot_micr
 Person: Rebecca Firth
 Working Group: []
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Youthmappers.jpg
 created: 1501727509

--- a/_posts/2017-08-07-legit-completes-field-mapping-in-three-cities-in-liberia.md
+++ b/_posts/2017-08-07-legit-completes-field-mapping-in-three-cities-in-liberia.md
@@ -4,7 +4,7 @@ date: 2017-08-07 15:12:16 Z
 permalink: updates/2017-08-07_legit_completes_field_mapping_in_three_cities_in_liberia
 Person: David Luswata
 Working Group: []
-Projects:
+Project:
 - 'LEGIT: Supporting decentralization in Liberian cities'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/01.png
 created: 1502118736

--- a/_posts/2017-08-07-openstreetmap-for-rural-development-and-poverty-eradication.md
+++ b/_posts/2017-08-07-openstreetmap-for-rural-development-and-poverty-eradication.md
@@ -4,7 +4,7 @@ date: 2017-08-07 10:00:35 Z
 permalink: updates/2017-08-07_openstreetmap_for_rural_development_and_poverty_eradication
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-08-07+at+4.58.52+PM.png
 created: 1502100035

--- a/_posts/2017-08-09-making-hots-design-experience-sizzle.md
+++ b/_posts/2017-08-09-making-hots-design-experience-sizzle.md
@@ -4,7 +4,7 @@ date: 2017-08-09 12:20:11 Z
 permalink: updates/2017-08-09_making_hot’s_design_experience_sizzle
 Person: Nate Smith
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-08-09+at+2.07.15+PM.png
 created: 1502281211
 ---

--- a/_posts/2017-08-10-hot-and-heidelberg-institution-for-geoinformation-technology-collaborations.md
+++ b/_posts/2017-08-10-hot-and-heidelberg-institution-for-geoinformation-technology-collaborations.md
@@ -4,7 +4,7 @@ date: 2017-08-10 02:27:42 Z
 permalink: updates/2017-08-10_hot_and_heidelberg_institution_for_geoinformation_technology_collaborations
 Person: Rebecca Firth
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-08-09+at+21.30.45.png
 created: 1502332062
 ---

--- a/_posts/2017-08-17-1-month-til-the-hot-summit-2017-in-ottawa-ontario.md
+++ b/_posts/2017-08-17-1-month-til-the-hot-summit-2017-in-ottawa-ontario.md
@@ -4,7 +4,7 @@ date: 2017-08-17 15:15:20 Z
 permalink: updates/2017-08-17_1_month_til_the_hot_summit_2017_in_ottawa_ontario!
 Person: Rachel VanNice
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Summit+Blog+1+(6).png
 created: 1502982920
 ---

--- a/_posts/2017-08-18-field-mapping-organizer-reaches-first-major-milestone.md
+++ b/_posts/2017-08-18-field-mapping-organizer-reaches-first-major-milestone.md
@@ -4,7 +4,7 @@ date: 2017-08-18 11:09:01 Z
 permalink: updates/2017-08-18_field_mapping_organizer_reaches_first_major_milestone
 Person: Nate Smith
 Working Group: []
-Projects:
+Project:
 - 'Urban Innovations: Crowdsourcing Non-Camp Refugee Data'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_20160119_102604-compressor.jpg
 created: 1503054541

--- a/_posts/2017-08-23-sharing-experiences-osm-mapping-in-four-countries-armenia-bangladesh-fiji-and-the-philippines.md
+++ b/_posts/2017-08-23-sharing-experiences-osm-mapping-in-four-countries-armenia-bangladesh-fiji-and-the-philippines.md
@@ -5,7 +5,7 @@ date: 2017-08-23 22:34:20 Z
 permalink: updates/2017-08-23_sharing_experiences_osm_mapping_in_four_countries_armenia_bangladesh_fiji_and_th
 Person: Rebecca Firth
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/image5.png
 created: 1503527660
 ---

--- a/_posts/2017-09-06-humanitarian-openstreetmap-team-and-unhcr-work-together-to-empower-refugees-and-hosting-communities-.md
+++ b/_posts/2017-09-06-humanitarian-openstreetmap-team-and-unhcr-work-together-to-empower-refugees-and-hosting-communities-.md
@@ -6,7 +6,7 @@ permalink: updates/2017-09-06_humanitarian_openstreetmap_team_and_unhcr_work_tog
 Person: Geoffrey Kateregga
 Working Group:
 - Training
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/melisa.jpeg
 created: 1504721287
 ---

--- a/_posts/2017-09-07-mapping-administrative-boundaries-and-evacuation-routes-for-the-pacific-disaster-center-and-bnpbs-in.md
+++ b/_posts/2017-09-07-mapping-administrative-boundaries-and-evacuation-routes-for-the-pacific-disaster-center-and-bnpbs-in.md
@@ -5,7 +5,7 @@ date: 2017-09-07 06:41:50 Z
 permalink: updates/2017-09-07_mapping_administrative_boundaries_and_evacuation_routes_for_the_pacific_disaster
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - 'USAID '
 - " BNPB "
 - " InAWARE: Disaster Management Early Warning and Decision Support Capacity Enhancement

--- a/_posts/2017-09-08-first-ever-youthmappers-video-challenge.md
+++ b/_posts/2017-09-08-first-ever-youthmappers-video-challenge.md
@@ -4,7 +4,7 @@ date: 2017-09-08 21:48:49 Z
 permalink: updates/2017-09-08_first_ever_youthmappers_video_challenge_
 Person: Rachel VanNice
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/youthmappers.jpg
 created: 1504907329
 ---

--- a/_posts/2017-09-09-hot-activates-for-three-disasters-hurricane-irma-mexico-earthquake-bangladesh-floods.md
+++ b/_posts/2017-09-09-hot-activates-for-three-disasters-hurricane-irma-mexico-earthquake-bangladesh-floods.md
@@ -11,7 +11,7 @@ Summary Text: Cette première semaine de septembre 2017 a vu se produire des cat
 Person: Rebecca Firth
 Working Group:
 - Activation
-Projects:
+Project:
 - Fall 2017 Disaster Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-09-08+at+22.29.14.png
 created: 1504928114

--- a/_posts/2017-09-19-export-tool-3-0-launched.md
+++ b/_posts/2017-09-19-export-tool-3-0-launched.md
@@ -8,7 +8,7 @@ Summary Text: 'Version 3 of the Export Tool officially LAUNCHED on 18th Septembe
 Person: Mhairi O'Hara
 Working Group:
 - Technical
-Projects:
+Project:
 - 'Export Tool 3.0 '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-09-18+at+22.08.50.png
 created: 1505787917

--- a/_posts/2017-09-25-export-tool-01-selecting-area-of-interest.md
+++ b/_posts/2017-09-25-export-tool-01-selecting-area-of-interest.md
@@ -10,7 +10,7 @@ Summary Text: 'This blog focuses on how to ''Select Area of Interest'', and is t
 Person: Mhairi O'Hara
 Working Group:
 - Technical
-Projects:
+Project:
 - 'Export Tool 3.0 '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Untitled+presentation.png
 created: 1506375708

--- a/_posts/2017-09-26-hot-activates-for-five-disasters-update.md
+++ b/_posts/2017-09-26-hot-activates-for-five-disasters-update.md
@@ -5,7 +5,7 @@ permalink: updates/2017-09-26_hot_activates_for_five_disasters_update
 Person: Rebecca Firth
 Working Group:
 - Activation
-Projects:
+Project:
 - Fall 2017 Disaster Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-09-29+at+12.27.20.png
 created: 1506410086

--- a/_posts/2017-09-26-hot-summit-2017.md
+++ b/_posts/2017-09-26-hot-summit-2017.md
@@ -4,7 +4,7 @@ date: 2017-09-26 20:27:44 Z
 permalink: updates/2017-09-26_hot_summit_2017-_
 Person: Rachel VanNice
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_2897.JPG
 created: 1506457664
 ---

--- a/_posts/2017-10-02-microgrants-humanitarian-mapping-of-coastal-wetlands-and-fishing-livelihoods-for-resilience-to-clima.md
+++ b/_posts/2017-10-02-microgrants-humanitarian-mapping-of-coastal-wetlands-and-fishing-livelihoods-for-resilience-to-clima.md
@@ -6,7 +6,7 @@ permalink: updates/2017-10-02_microgrants_humanitarian_mapping_of_coastal_wetlan
 Person: Rebecca Firth
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Photo+1+Bahía+El+Uno+aerial.JPG
 created: 1506965660

--- a/_posts/2017-10-03-export-tool-02-data-file-formats.md
+++ b/_posts/2017-10-03-export-tool-02-data-file-formats.md
@@ -9,7 +9,7 @@ Summary Text: 'This blog is the second in a series of ‘Learn Export Tool’ po
   will cover how to ‘Customise Map Features’ and examples of ‘Applying Exported Data’. '
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - 'Export Tool 3.0 '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Export+Tool+-+Learn+Series.png
 created: 1507061324

--- a/_posts/2017-10-04-malaria-elimination-mapping-continues.md
+++ b/_posts/2017-10-04-malaria-elimination-mapping-continues.md
@@ -9,7 +9,7 @@ Summary Text: HOT has teamed up with many partners working to eliminate the dise
   places.
 Person: Russell Deffner
 Working Group: []
-Projects:
+Project:
 - Malaria Elimination Campaign
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/140909154833-malaria-map-story-top.jpg
 created: 1507129249

--- a/_posts/2017-10-10-export-tool-03-customise-map-features.md
+++ b/_posts/2017-10-10-export-tool-03-customise-map-features.md
@@ -9,7 +9,7 @@ Summary Text: 'This blog is the third in a series of ‘Learn Export Tool’ pos
   last will look at examples of ‘Applying Exported Data’. '
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - 'Export Tool 3.0 '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Export+Tool+-+Learn+Series.png
 created: 1507601156

--- a/_posts/2017-10-10-fall-2017-disaster-response-calling-all-mappers.md
+++ b/_posts/2017-10-10-fall-2017-disaster-response-calling-all-mappers.md
@@ -6,7 +6,7 @@ Summary Text: HOT continues response to multiple disasters...
 Person: Russell Deffner
 Working Group:
 - Activation
-Projects:
+Project:
 - Fall 2017 Disaster Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/MexicoEarthquakes.PNG
 created: 1507660108

--- a/_posts/2017-10-17-fubu.md
+++ b/_posts/2017-10-17-fubu.md
@@ -4,7 +4,7 @@ date: 2017-10-17 19:21:45 Z
 permalink: updates/2017-10-17_fubu
 Person: Pete Masters
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/boardv2_Sept17.JPG
 created: 1508268105
 ---

--- a/_posts/2017-10-18-new-tasking-manager-3-coming-today.md
+++ b/_posts/2017-10-18-new-tasking-manager-3-coming-today.md
@@ -9,7 +9,7 @@ Summary Text: After several months of development work and 20,000+ lines of new 
   next several days, but you can get an introduction and preview of it now.
 Person: Blake Girardot
 Working Group: []
-Projects:
+Project:
 - Tasking Manager
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/2017-09-05_20h51_07.png
 created: 1508311109

--- a/_posts/2017-10-24-grabbike-drivers-support-disaster-managers-identify-idp-camps-in-bali.md
+++ b/_posts/2017-10-24-grabbike-drivers-support-disaster-managers-identify-idp-camps-in-bali.md
@@ -4,7 +4,7 @@ date: 2017-10-24 07:34:57 Z
 permalink: updates/2017-10-24_grabbike_drivers_support_disaster_managers_identify_idp_camps_in_bali
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - Indonesia Disaster Management Innovation
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/All+Participants.png
 created: 1508830497

--- a/_posts/2017-10-25-export-tool-04-applying-exported-data.md
+++ b/_posts/2017-10-25-export-tool-04-applying-exported-data.md
@@ -9,7 +9,7 @@ Summary Text: This blog is the final in a series of ‘Learn Export Tool’ post
   Formats’ and the third looked at ‘Customising Map Features’.
 Person: Mhairi O'Hara
 Working Group: []
-Projects:
+Project:
 - 'Export Tool 3.0 '
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Export+Tool+-+Learn+Series.png
 created: 1508906811

--- a/_posts/2017-10-25-get-excited-for-osm-geoweek-2017-help-us-break-a-mapathon-record.md
+++ b/_posts/2017-10-25-get-excited-for-osm-geoweek-2017-help-us-break-a-mapathon-record.md
@@ -4,7 +4,7 @@ date: 2017-10-25 19:48:03 Z
 permalink: updates/2017-10-25_get_excited_for_osm_geoweek_2017-_help_us_break_a_mapathon_record!
 Person: Rachel VanNice
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/33183211886_891b16040d_o.jpg
 created: 1508960883
 ---

--- a/_posts/2017-10-26-team-in-istanbul-conducts-training-for-small-projects-istanbul.md
+++ b/_posts/2017-10-26-team-in-istanbul-conducts-training-for-small-projects-istanbul.md
@@ -4,7 +4,7 @@ date: 2017-10-26 13:28:30 Z
 permalink: updates/2017-10-26_team_in_istanbul_conducts_training_for_small_projects_istanbul
 Person: Paul Uithol
 Working Group: []
-Projects:
+Project:
 - 'Urban Innovations: Crowdsourcing Non-Camp Refugee Data'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Copy-of-SPI-PROJECT1.jpg
 created: 1509024510

--- a/_posts/2017-10-27-osm-puerto-rico-emerges-stronger-and-ready-to-help-rebuild.md
+++ b/_posts/2017-10-27-osm-puerto-rico-emerges-stronger-and-ready-to-help-rebuild.md
@@ -11,7 +11,7 @@ Summary Text: As Hurricane Maria‘s winds and rain battered our home in San Jua
 Person: Russell Deffner
 Working Group:
 - Activation
-Projects:
+Project:
 - Fall 2017 Disaster Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/pasted+image+0.png
 created: 1509134906

--- a/_posts/2017-10-30-code-of-conduct.md
+++ b/_posts/2017-10-30-code-of-conduct.md
@@ -5,7 +5,7 @@ permalink: updates/2017-10-30_code_of_conduct
 Person: Dale Kunce
 Working Group:
 - Governance
-Projects: []
+Project: []
 created: 1509381498
 ---
 

--- a/_posts/2017-10-31-mapping-the-thousand-islands-in-the-face-of-climate-induced-disasters.md
+++ b/_posts/2017-10-31-mapping-the-thousand-islands-in-the-face-of-climate-induced-disasters.md
@@ -4,7 +4,7 @@ date: 2017-10-31 06:31:39 Z
 permalink: updates/2017-10-31_mapping_the_thousand_islands_in_the_face_of_climate-induced_disasters
 Person: Biondi Sanda Sima
 Working Group: []
-Projects:
+Project:
 - 'USAID '
 - " BNPB "
 - " InAWARE: Disaster Management Early Warning and Decision Support Capacity Enhancement

--- a/_posts/2017-11-02-hot-microgrant-mafalala-mozambique-mapping-history-with-a-focus-on-the-future.md
+++ b/_posts/2017-11-02-hot-microgrant-mafalala-mozambique-mapping-history-with-a-focus-on-the-future.md
@@ -6,7 +6,7 @@ permalink: updates/2017-11-02_hot_microgrant_mafalala_mozambique_-_mapping_histo
 Person: Rebecca Firth
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-11-02+at+21.00.42.png
 created: 1509652826

--- a/_posts/2017-11-05-ramani-huria-building-open-tools-to-map-drains.md
+++ b/_posts/2017-11-05-ramani-huria-building-open-tools-to-map-drains.md
@@ -5,8 +5,8 @@ permalink: updates/2017-11-05_ramani_huria_building_open_tools_to_map_drains
 Person: Innocent Maholi
 Working Group:
 - Community
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/ino.jpg
 created: 1509898516
 ---

--- a/_posts/2017-11-09-building-openstreetmap-zambia-with-the-help-of-a-hot-microgrant.md
+++ b/_posts/2017-11-09-building-openstreetmap-zambia-with-the-help-of-a-hot-microgrant.md
@@ -5,7 +5,7 @@ permalink: updates/2017-11-09_building_openstreetmap_zambia_with_the_help_of_a_h
 Person: Rebecca Firth
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2017-11-09+at+13.23.25.png
 created: 1510252014

--- a/_posts/2017-11-10-calling-all-validators-and-mappers.md
+++ b/_posts/2017-11-10-calling-all-validators-and-mappers.md
@@ -10,7 +10,7 @@ Summary Text: HOT begins to transition mapping of critical data in response to t
 Person: Russell Deffner
 Working Group:
 - Activation
-Projects:
+Project:
 - Fall 2017 Disaster Response
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/CaribbeanHurricanes1109.png
 created: 1510339463

--- a/_posts/2017-11-22-hot-tech-in-2018.md
+++ b/_posts/2017-11-22-hot-tech-in-2018.md
@@ -5,7 +5,7 @@ permalink: updates/2017-11-22_hot_tech_in_2018
 Person: Nate Smith
 Working Group:
 - Technical
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_7347.JPG
 created: 1511367042
 ---

--- a/_posts/2017-11-28-we-can-mapthedifference-together-in-2018.md
+++ b/_posts/2017-11-28-we-can-mapthedifference-together-in-2018.md
@@ -4,7 +4,7 @@ date: 2017-11-28 23:06:30 Z
 permalink: updates/2017-11-28_we_can_#mapthedifference_together_in_2018!
 Person: Rachel VanNice
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/northern+uganda+bidibidi+(1).jpg
 created: 1511910390
 ---

--- a/_posts/2017-12-05-openstreetmap-and-qgis-training-for-geology-students-in-bamako-mali.md
+++ b/_posts/2017-12-05-openstreetmap-and-qgis-training-for-geology-students-in-bamako-mali.md
@@ -5,7 +5,7 @@ permalink: updates/2017-12-05_openstreetmap_&_qgis_training_for_geology_students
 Person: 'Amelia Hunt '
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/title+image.jpg
 created: 1512478000

--- a/_posts/2017-12-06-mapping-arsenic-contamination-youth-mappers-at-auw-bangladesh.md
+++ b/_posts/2017-12-06-mapping-arsenic-contamination-youth-mappers-at-auw-bangladesh.md
@@ -5,7 +5,7 @@ permalink: updates/2017-12-06_mapping_arsenic_contamination_-_youth_mappers_at_a
 Person: 'Amelia Hunt '
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Capture.JPG
 created: 1512565874

--- a/_posts/2017-12-11-openstreetmap-niger-scaling-with-the-help-of-a-microgrant.md
+++ b/_posts/2017-12-11-openstreetmap-niger-scaling-with-the-help-of-a-microgrant.md
@@ -5,7 +5,7 @@ permalink: updates/2017-12-11_openstreetmap_niger_scaling_with_the_help_of_a_mic
 Person: 'Amelia Hunt '
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_20171012_1012162.JPG
 created: 1513023415

--- a/_posts/2017-12-13-the-first-state-of-the-map-tanzania-2017.md
+++ b/_posts/2017-12-13-the-first-state-of-the-map-tanzania-2017.md
@@ -5,8 +5,8 @@ permalink: updates/2017-12-13_the_first_state_of_the_map_tanzania_-_2017
 Person: Innocent Maholi
 Working Group:
 - Community
-Projects:
-- Dar Ramani Huria - Dar Open Map
+Project:
+- Dar Ramani Huria — Dar Open Map
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_4336copy.jpg
 created: 1513151746
 ---

--- a/_posts/2018-01-10-expanding-the-mapping-community-in-turkey.md
+++ b/_posts/2018-01-10-expanding-the-mapping-community-in-turkey.md
@@ -5,7 +5,7 @@ permalink: updates/2018-01-10_expanding_the_mapping_community_in_turkey
 Person: 'Amelia Hunt '
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_1168_(1)+(1).jpg
 created: 1515586962

--- a/_posts/2018-01-16-help-support-3-local-openstreetmap-communities-dealing-with-disaster.md
+++ b/_posts/2018-01-16-help-support-3-local-openstreetmap-communities-dealing-with-disaster.md
@@ -8,7 +8,7 @@ Summary Text: 2018 has taken no time off from disasters and HOT is supporting th
 Person: Russell Deffner
 Working Group:
 - Activation
-Projects:
+Project:
 - HOT Training Center
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Mayon.PNG
 created: 1516139347

--- a/_posts/2018-01-17-funds-for-community-led-projects-to-improve-resilience-to-disasters-and-crises-the-2018-hot-microgra.md
+++ b/_posts/2018-01-17-funds-for-community-led-projects-to-improve-resilience-to-disasters-and-crises-the-2018-hot-microgra.md
@@ -6,7 +6,7 @@ permalink: updates/2018-01-17_funds_for_community-led_projects_to_improve_resili
 Person: Rebecca Firth
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2018-01-17+at+11.16.24.png
 created: 1516205301

--- a/_posts/2018-01-18-nethope-device-challenge-providing-devices-and-training-to-12-osm-communities-update.md
+++ b/_posts/2018-01-18-nethope-device-challenge-providing-devices-and-training-to-12-osm-communities-update.md
@@ -6,7 +6,7 @@ permalink: updates/2018-01-18_nethope_device_challenge_providing_devices_and_tra
 Person: 'Amelia Hunt '
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/IMG_20171114_113048.jpg
 created: 1516261094

--- a/_posts/2018-01-24-community-mapping-in-north-uganda-intrepid-refugees-and-host-community-compare-needs.md
+++ b/_posts/2018-01-24-community-mapping-in-north-uganda-intrepid-refugees-and-host-community-compare-needs.md
@@ -6,7 +6,7 @@ permalink: updates/2018-01-24_community_mapping_in_north_uganda_-_intrepid_refug
 Person: Rupert Allan
 Working Group:
 - Communications
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/MosesMawa+Intrepid+Refugee+SurveyorSmall.jpeg
 created: 1516788207
 ---

--- a/_posts/2018-01-31-thanks-to-you-were-mapping-the-difference-for-disasters-in-2018.md
+++ b/_posts/2018-01-31-thanks-to-you-were-mapping-the-difference-for-disasters-in-2018.md
@@ -5,7 +5,7 @@ permalink: updates/2018-01-31_thanks_to_you_we're_mapping_the_difference_for_dis
 Person: Rachel VanNice
 Working Group:
 - Fundraising
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Campaign+Header+1.jpg
 created: 1517434023
 ---

--- a/_posts/2018-02-06-hot-2018-microgrants-programme-launch.md
+++ b/_posts/2018-02-06-hot-2018-microgrants-programme-launch.md
@@ -4,7 +4,7 @@ date: 2018-02-06 07:45:46 Z
 permalink: updates/2018-02-06_hot_2018_microgrants_programme_launch!
 Person: Rebecca Firth
 Working Group: []
-Projects: []
+Project: []
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/Screen+Shot+2018-01-17+at+11.16.24.png
 created: 1517903146
 ---

--- a/_posts/2018-02-14-from-the-use-of-classic-gps-to-the-smartphone-how-osmand-allows-students-of-the-uglcs-youthmappers-c.md
+++ b/_posts/2018-02-14-from-the-use-of-classic-gps-to-the-smartphone-how-osmand-allows-students-of-the-uglcs-youthmappers-c.md
@@ -6,7 +6,7 @@ permalink: updates/2018-02-14_from_the_use_of_classic_gps_to_the_smartphone_how_
 Person: 'Amelia Hunt '
 Working Group:
 - Community
-Projects:
+Project:
 - Microgrants and Community Development
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/3_1.jpg
 created: 1518611304

--- a/_posts/2018-02-16-gis-training-for-legit-stakeholders-in-liberia.md
+++ b/_posts/2018-02-16-gis-training-for-legit-stakeholders-in-liberia.md
@@ -4,7 +4,7 @@ date: 2018-02-16 07:49:25 Z
 permalink: updates/2018-02-16_gis_training_for_legit_stakeholders_in_liberia
 Person: David Luswata
 Working Group: []
-Projects:
+Project:
 - 'LEGIT: Supporting decentralization in Liberian cities'
 Feature Image: https://s3.amazonaws.com/hotwww/files/old/styles/banner/public/01.jpg
 created: 1518767365

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -1947,9 +1947,10 @@ em {
 }
 
 .meta {
+  line-height: 1.3;
   p, li {
     color: $blue-dark;
-    margin-top: 8px;
+    margin-top: 6px;
   }
   a {
     color: $blue-dark;
@@ -1961,7 +1962,7 @@ em {
 
 .meta-item {
   padding-bottom: 24px;
-  margin-bottom: 24px;
+  margin-bottom: 22px;
   border-bottom: 1px solid $border-color;
 }
 

--- a/what-we-do.markdown
+++ b/what-we-do.markdown
@@ -14,7 +14,7 @@ Block 1:
     come together online and on the ground to create open map data that enables disaster
     responders to reach those in need.
   Image: https://source.unsplash.com/collection/1118917/800x600?v=1
-  Projects:
+  Project:
   - 'Urban Innovations: Crowdsourcing Non-Camp Refugee Data'
 Block 2:
   Header: Putting the world's most vulnerable people and places on the map
@@ -22,7 +22,7 @@ Block 2:
     high vulnerability areas where data is scarce, putting millions of people onto
     the world map in OpenStreetMap.
   Image: https://source.unsplash.com/collection/207682/800x600?v=1
-  Projects:
+  Project:
   - Malaria Elimination Campaign
   - Microgrants and Community Development
 Block 3:
@@ -31,7 +31,7 @@ Block 3:
     partners to use and contribute to OpenStreetMap for locally-relevant challenges
     through provision of training, equipment, knowledge exchange, and field projects.
   Image: https://source.unsplash.com/collection/851614/800x600?v=1
-  Projects:
+  Project:
   - 'LEGIT: Supporting decentralization in Liberian cities'
 layout: what-we-do
 ---


### PR DESCRIPTION
Associated projects now showing on news items. Along with this, I've done a big find and replace to change the metadata from `Projects` to `Project` so that Siteleaf will pick up and let you choose an individual Project from the Projects collection when adding/editing a news item.

Another find and replace was done to make sure the same dash is being used across the site for the title `Dar Ramani Huria — Dar Open Map`. Inconsistency between dashes and hyphens in that title were preventing the project from being properly linked.

Working group links are now functional as well, although each link just takes you to the index for `/working-groups`.