### PR TITLE
update project thumbnails so image isn't shown if missing

### DIFF
--- a/_includes/blocks/project-highlight.html
+++ b/_includes/blocks/project-highlight.html
@@ -27,7 +27,9 @@
     <p class="module-cta"><span>Learn more</span></p>
   </div>
   <div class="module-image">
-    <img src="{{ project['Feature Image']}}">
+    {% if project['Feature Image'] %}
+      <img src="{{ project['Feature Image']}}">
+    {% endif %}
   </div>
 
 </a>

--- a/_includes/blocks/project-thumb.html
+++ b/_includes/blocks/project-thumb.html
@@ -27,7 +27,9 @@
   </div>
 
   <div class="module-image">
-    <img src="{{ project['Feature Image']}}">
+    {% if project['Feature Image'] %}
+      <img src="{{ project['Feature Image']}}">
+    {% endif %}
   </div>
 
 </a>


### PR DESCRIPTION
PR to not show a broken image if the project is missing an image. All projects should have an image but this will help the page not to look broken as we edit content and add images back in. 