### PR TITLE
add jekyll-redirect-from plugin, change metadata for each person

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'jekyll-paginate'
+gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
     jekyll-feed (0.9.3)
       jekyll (~> 3.3)
     jekyll-paginate (1.1.0)
+    jekyll-redirect-from (0.13.0)
+      jekyll (~> 3.3)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
     jekyll-watch (1.5.0)
@@ -53,6 +55,7 @@ DEPENDENCIES
   jekyll (= 3.5.2)
   jekyll-feed (~> 0.6)
   jekyll-paginate
+  jekyll-redirect-from
   minima (~> 2.0)
   tzinfo-data
 

--- a/_config.yml
+++ b/_config.yml
@@ -141,5 +141,6 @@ theme: minima
 plugins:
 - jekyll-feed
 - jekyll-paginate
+- jekyll-redirect-from
 paginate: 16
 paginate_path: "/updates/page:num/"

--- a/_people/aaron-cope.md
+++ b/_people/aaron-cope.md
@@ -1,7 +1,8 @@
 ---
 title: Aaron Cope
 date: 2014-09-30 03:15:00 Z
-permalink: users/aaron_cope
+redirect_from:
+  - /users/aaron_cope
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/adhitya-dido.md
+++ b/_people/adhitya-dido.md
@@ -1,7 +1,8 @@
 ---
 title: 'Adhitya Dido '
 date: 2016-12-15 19:21:07 Z
-permalink: users/adhitya_dido_
+redirect_from:
+  - /users/adhitya_dido_
 Country: Indonesia
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-348-1481831993.png
 ---

--- a/_people/adityo-dwijananto.md
+++ b/_people/adityo-dwijananto.md
@@ -1,7 +1,8 @@
 ---
 title: Adityo Dwijananto
 date: 2016-01-11 23:46:00 Z
-permalink: users/adityo_dwijananto
+redirect_from:
+  - /users/adityo_dwijananto
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-326-1466048750.jpg
 Member Type:
   Is Staff: true

--- a/_people/ahasanul-hoque.md
+++ b/_people/ahasanul-hoque.md
@@ -1,7 +1,8 @@
 ---
 title: Ahasanul Hoque
 date: 2016-01-11 23:36:00 Z
-permalink: users/ahasanul_hoque
+redirect_from:
+  - /users/ahasanul_hoque
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-319-1452842533.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/alce-samuel-paul.md
+++ b/_people/alce-samuel-paul.md
@@ -1,7 +1,8 @@
 ---
 title: ALCE Samuel Paul
 date: 2014-09-30 03:17:00 Z
-permalink: users/alce_samuel_paul
+redirect_from:
+  - /users/alce_samuel_paul
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-204-1412073308.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/alyssa-wright.md
+++ b/_people/alyssa-wright.md
@@ -1,7 +1,8 @@
 ---
 title: Alyssa Wright
 date: 2013-05-08 04:56:14 Z
-permalink: users/alyssa_wright
+redirect_from:
+  - /users/alyssa_wright
 Country: United States
 Social Media (Full URL):
   LinkedIn: https://www.linkedin.com/pub/alyssa-wright/4/79/7a8

--- a/_people/amadou-ndong.md
+++ b/_people/amadou-ndong.md
@@ -1,7 +1,8 @@
 ---
 title: Amadou Ndong
 date: 2014-09-30 03:28:00 Z
-permalink: users/amadou_ndong
+redirect_from:
+  - /users/amadou_ndong
 Member Type:
   Is Voting Member: true
 Project:

--- a/_people/amelia-hunt.md
+++ b/_people/amelia-hunt.md
@@ -1,7 +1,8 @@
 ---
 title: 'Amelia Hunt '
 date: 2017-11-22 16:08:18 Z
-permalink: users/amelia_hunt_
+redirect_from:
+  - /users/amelia_hunt_
 Working Group:
 - Community
 - Communications

--- a/_people/andrew-buck.md
+++ b/_people/andrew-buck.md
@@ -1,7 +1,8 @@
 ---
 title: Andrew Buck
 date: 2014-09-30 03:18:00 Z
-permalink: users/andrew_buck
+redirect_from:
+  - /users/andrew_buck
 Member Type:
   Is Voting Member: true
 Working Group:

--- a/_people/andrew-turner.md
+++ b/_people/andrew-turner.md
@@ -1,7 +1,8 @@
 ---
 title: Andrew Turner
 date: 2014-09-30 03:15:00 Z
-permalink: users/andrew_turner
+redirect_from:
+  - /users/andrew_turner
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/andrew-wiseman.md
+++ b/_people/andrew-wiseman.md
@@ -1,7 +1,8 @@
 ---
 title: Andrew Wiseman
 date: 2015-04-28 20:22:00 Z
-permalink: users/andrew_wiseman
+redirect_from:
+  - /users/andrew_wiseman
 Project:
 - Nepal 2015 Earthquake Response
 - 'Haiti '

--- a/_people/anna-hodgkinson.md
+++ b/_people/anna-hodgkinson.md
@@ -1,6 +1,7 @@
 ---
 title: Anna Hodgkinson
 date: 2014-09-30 03:25:01 Z
-permalink: users/anna_hodgkinson
+redirect_from:
+  - /users/anna_hodgkinson
 ---
 

--- a/_people/antje-lorch.md
+++ b/_people/antje-lorch.md
@@ -1,7 +1,8 @@
 ---
 title: Antje Lorch
 date: 2013-07-22 16:10:52 Z
-permalink: users/antje_lorch
+redirect_from:
+  - /users/antje_lorch
 Working Group:
 - Technical
 Country: United Kingdom

--- a/_people/awa-dia.md
+++ b/_people/awa-dia.md
@@ -1,7 +1,8 @@
 ---
 title: Awa Dia
 date: 2014-09-30 03:18:00 Z
-permalink: users/awa_dia
+redirect_from:
+  - /users/awa_dia
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-207-1432575659.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/bagnoumana-bazo-fofana.md
+++ b/_people/bagnoumana-bazo-fofana.md
@@ -1,7 +1,8 @@
 ---
 title: BAGNOUMANA Bazo FOFANA
 date: 2015-06-04 19:45:00 Z
-permalink: users/bagnoumana_bazo_fofana
+redirect_from:
+  - /users/bagnoumana_bazo_fofana
 Member Type:
   Is Voting Member: true
 Working Group:

--- a/_people/baiduri-ismayanti-fitriana.md
+++ b/_people/baiduri-ismayanti-fitriana.md
@@ -1,7 +1,8 @@
 ---
 title: Baiduri Ismayanti Fitriana
 date: 2016-12-15 19:23:43 Z
-permalink: users/baiduri_ismayanti_fitriana
+redirect_from:
+  - /users/baiduri_ismayanti_fitriana
 Country: Indonesia
 Social Media (Full URL):
   Facebook: https://www.facebook.com/baiduri.i.ismail

--- a/_people/ben-abelshausen.md
+++ b/_people/ben-abelshausen.md
@@ -1,7 +1,8 @@
 ---
 title: Ben Abelshausen
 date: 2015-06-04 19:47:00 Z
-permalink: users/ben_abelshausen
+redirect_from:
+  - /users/ben_abelshausen
 Member Type:
   Is Voting Member: true
 Project:

--- a/_people/benot-fournier.md
+++ b/_people/benot-fournier.md
@@ -1,7 +1,8 @@
 ---
 title: Benoît Fournier
 date: 2016-01-11 23:41:00 Z
-permalink: users/benoît_fournier
+redirect_from:
+  - /users/benoît_fournier
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-323-1452590168.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/besfort-guri.md
+++ b/_people/besfort-guri.md
@@ -1,7 +1,8 @@
 ---
 title: Besfort Guri
 date: 2014-09-30 03:19:00 Z
-permalink: users/besfort_guri
+redirect_from:
+  - /users/besfort_guri
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-208-1432131324.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/biondi-sanda-sima.md
+++ b/_people/biondi-sanda-sima.md
@@ -1,7 +1,8 @@
 ---
 title: Biondi Sanda Sima
 date: 2014-04-17 18:25:00 Z
-permalink: users/biondi_sanda_sima
+redirect_from:
+  - /users/biondi_sanda_sima
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-83-1482132491.jpg
 Member Type:
   Is Staff: true

--- a/_people/blake-girardot.md
+++ b/_people/blake-girardot.md
@@ -1,7 +1,8 @@
 ---
 title: Blake Girardot
 date: 2015-01-21 19:58:00 Z
-permalink: users/blake_girardot
+redirect_from:
+  - /users/blake_girardot
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-250-1455894309.jpg
 Member Type:
   Is Staff: true

--- a/_people/boris-mogwitz.md
+++ b/_people/boris-mogwitz.md
@@ -1,7 +1,8 @@
 ---
 title: Boris Mogwitz
 date: 2014-09-30 03:29:00 Z
-permalink: users/boris_mogwitz
+redirect_from:
+  - /users/boris_mogwitz
 Member Type:
   Is Voting Member: true
 Country: Germany

--- a/_people/boukpessi-bital.md
+++ b/_people/boukpessi-bital.md
@@ -1,7 +1,8 @@
 ---
 title: BOUKPESSI Bitalé
 date: 2015-06-04 19:48:00 Z
-permalink: users/boukpessi_bitalé
+redirect_from:
+  - /users/boukpessi_bitalé
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/brendan-gatens.md
+++ b/_people/brendan-gatens.md
@@ -1,6 +1,7 @@
 ---
 title: Brendan Gatens
 date: 2018-02-16 15:27:01 Z
-permalink: users/brendan_gatens
+redirect_from:
+  - /users/brendan_gatens
 ---
 

--- a/_people/brian-wolford.md
+++ b/_people/brian-wolford.md
@@ -1,7 +1,8 @@
 ---
 title: Brian Wolford
 date: 2012-01-23 13:36:00 Z
-permalink: users/brian_wolford
+redirect_from:
+  - /users/brian_wolford
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/chad-blevins.md
+++ b/_people/chad-blevins.md
@@ -1,7 +1,8 @@
 ---
 title: Chad Blevins
 date: 2017-02-28 14:26:00 Z
-permalink: users/chad_blevins
+redirect_from:
+  - /users/chad_blevins
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/cheryl-shaw.md
+++ b/_people/cheryl-shaw.md
@@ -1,7 +1,8 @@
 ---
 title: Cheryl Shaw
 date: 2016-04-28 12:49:32 Z
-permalink: users/cheryl_shaw
+redirect_from:
+  - /users/cheryl_shaw
 Working Group:
 - Fundraising
 - Communications

--- a/_people/chris-blow.md
+++ b/_people/chris-blow.md
@@ -1,7 +1,8 @@
 ---
 title: Chris Blow
 date: 2011-07-15 09:39:42 Z
-permalink: users/chris_blow
+redirect_from:
+  - /users/chris_blow
 Project:
 - Indonesia Disaster Management Innovation
 Country: United States

--- a/_people/chris-daley.md
+++ b/_people/chris-daley.md
@@ -1,7 +1,8 @@
 ---
 title: Chris Daley
 date: 2014-11-05 03:32:36 Z
-permalink: users/chris_daley
+redirect_from:
+  - /users/chris_daley
 Country: Australia
 Social Media (Full URL):
   Twitter: https://twitter.com/chebizarro

--- a/_people/claire-halleux.md
+++ b/_people/claire-halleux.md
@@ -1,7 +1,8 @@
 ---
 title: Claire Halleux
 date: 2013-02-11 14:11:00 Z
-permalink: users/claire_halleux
+redirect_from:
+  - /users/claire_halleux
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-49-1411584011.png
 Member Type:
   Is Voting Member: true

--- a/_people/courtney-clark.md
+++ b/_people/courtney-clark.md
@@ -1,7 +1,8 @@
 ---
 title: Courtney Clark
 date: 2016-01-11 23:44:00 Z
-permalink: users/courtney_clark
+redirect_from:
+  - /users/courtney_clark
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-325-1454006265.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/cristiano-giovando.md
+++ b/_people/cristiano-giovando.md
@@ -1,7 +1,8 @@
 ---
 title: Cristiano Giovando
 date: 2015-01-21 20:32:00 Z
-permalink: users/cristiano_giovando
+redirect_from:
+  - /users/cristiano_giovando
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-251-1432768691.jpg
 Member Type:
   Is Staff: true

--- a/_people/dale-kunce.md
+++ b/_people/dale-kunce.md
@@ -1,7 +1,8 @@
 ---
 title: Dale Kunce
 date: 2014-09-30 03:20:00 Z
-permalink: users/dale_kunce
+redirect_from:
+  - /users/dale_kunce
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-210-1518189300.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/dan-joseph.md
+++ b/_people/dan-joseph.md
@@ -1,7 +1,8 @@
 ---
 title: Dan Joseph
 date: 2015-05-27 20:21:00 Z
-permalink: users/dan_joseph
+redirect_from:
+  - /users/dan_joseph
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-284-1432759370.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/dane-springmeyer.md
+++ b/_people/dane-springmeyer.md
@@ -1,7 +1,8 @@
 ---
 title: Dane Springmeyer
 date: 2010-05-24 15:42:00 Z
-permalink: users/dane_springmeyer
+redirect_from:
+  - /users/dane_springmeyer
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-6-1432176580.jpg
 Country: United States
 Social Media (Full URL):

--- a/_people/david-luswata.md
+++ b/_people/david-luswata.md
@@ -1,7 +1,8 @@
 ---
 title: David Luswata
 date: 2017-02-08 15:48:00 Z
-permalink: users/david_luswata
+redirect_from:
+  - /users/david_luswata
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-358-1487343133.jpg
 Member Type:
   Is Staff: true

--- a/_people/david-neudorfer.md
+++ b/_people/david-neudorfer.md
@@ -1,7 +1,8 @@
 ---
 title: David Neudorfer
 date: 2017-02-24 17:44:34 Z
-permalink: users/david_neudorfer
+redirect_from:
+  - /users/david_neudorfer
 Working Group:
 - Technical
 Country: United States

--- a/_people/delphine-bedu.md
+++ b/_people/delphine-bedu.md
@@ -1,7 +1,8 @@
 ---
 title: Delphine Bedu
 date: 2015-06-04 19:49:00 Z
-permalink: users/delphine_bedu
+redirect_from:
+  - /users/delphine_bedu
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/dewi-sulistioningrum.md
+++ b/_people/dewi-sulistioningrum.md
@@ -1,7 +1,8 @@
 ---
 title: Dewi Sulistioningrum
 date: 2017-02-28 14:17:00 Z
-permalink: users/dewi_sulistioningrum
+redirect_from:
+  - /users/dewi_sulistioningrum
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-378-1488526676.jpg
 Member Type:
   Is Staff: true

--- a/_people/douglas-ssebaggala.md
+++ b/_people/douglas-ssebaggala.md
@@ -1,7 +1,8 @@
 ---
 title: 'Douglas Ssebaggala '
 date: 2016-06-09 19:24:49 Z
-permalink: users/douglas_ssebaggala_
+redirect_from:
+  - /users/douglas_ssebaggala_
 Working Group:
 - Community
 Project:

--- a/_people/draen-odobai.md
+++ b/_people/draen-odobai.md
@@ -1,7 +1,8 @@
 ---
 title: Dražen Odobašić
 date: 2015-06-04 19:50:00 Z
-permalink: users/dražen_odobašić
+redirect_from:
+  - /users/dražen_odobašić
 Member Type:
   Is Staff: false
   Is Voting Member: true

--- a/_people/drishtie-patel.md
+++ b/_people/drishtie-patel.md
@@ -1,7 +1,8 @@
 ---
 title: Drishtie Patel
 date: 2016-01-11 23:37:00 Z
-permalink: users/drishtie_patel
+redirect_from:
+  - /users/drishtie_patel
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/dylan-moriarty.md
+++ b/_people/dylan-moriarty.md
@@ -1,7 +1,8 @@
 ---
 title: Dylan Moriarty
 date: 2017-02-28 14:25:00 Z
-permalink: users/dylan_moriarty
+redirect_from:
+  - /users/dylan_moriarty
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-385-1488293671.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/dylan-patterson.md
+++ b/_people/dylan-patterson.md
@@ -1,7 +1,8 @@
 ---
 title: Dylan Patterson
 date: 2018-01-12 10:21:34 Z
-permalink: users/dylan_patterson
+redirect_from:
+  - /users/dylan_patterson
 Country: Uganda
 ---
 

--- a/_people/elida-nurrohmah.md
+++ b/_people/elida-nurrohmah.md
@@ -1,7 +1,8 @@
 ---
 title: Elida Nurrohmah
 date: 2017-02-28 14:13:00 Z
-permalink: users/elida_nurrohmah
+redirect_from:
+  - /users/elida_nurrohmah
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/emily-eros.md
+++ b/_people/emily-eros.md
@@ -1,7 +1,8 @@
 ---
 title: Emily Eros
 date: 2016-01-11 23:43:00 Z
-permalink: users/emily_eros
+redirect_from:
+  - /users/emily_eros
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-324-1488822447.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/emir-hartato.md
+++ b/_people/emir-hartato.md
@@ -1,7 +1,8 @@
 ---
 title: Emir Hartato
 date: 2011-07-04 21:12:00 Z
-permalink: users/emir_hartato
+redirect_from:
+  - /users/emir_hartato
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-14-1497475546.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/enock-seth-nyamador.md
+++ b/_people/enock-seth-nyamador.md
@@ -1,7 +1,8 @@
 ---
 title: Enock Seth Nyamador
 date: 2017-02-28 14:02:00 Z
-permalink: users/enock_seth_nyamador
+redirect_from:
+  - /users/enock_seth_nyamador
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-370-1492038845.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/eugene-usvitsky.md
+++ b/_people/eugene-usvitsky.md
@@ -1,7 +1,8 @@
 ---
 title: Eugene Usvitsky
 date: 2014-09-30 03:21:00 Z
-permalink: users/eugene_usvitsky
+redirect_from:
+  - /users/eugene_usvitsky
 Member Type:
   Is Voting Member: true
 Project:

--- a/_people/felix-delattre.md
+++ b/_people/felix-delattre.md
@@ -1,7 +1,8 @@
 ---
 title: Felix Delattre
 date: 2013-12-01 16:40:00 Z
-permalink: users/felix_delattre
+redirect_from:
+  - /users/felix_delattre
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-72-1435074751.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/fran-boon.md
+++ b/_people/fran-boon.md
@@ -1,7 +1,8 @@
 ---
 title: Fran Boon
 date: 2014-09-30 03:22:00 Z
-permalink: users/fran_boon
+redirect_from:
+  - /users/fran_boon
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-214-1412247838.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/franois-xavier-lamure-tardieu.md
+++ b/_people/franois-xavier-lamure-tardieu.md
@@ -1,7 +1,8 @@
 ---
 title: François-Xavier Lamure Tardieu
 date: 2014-10-01 18:57:00 Z
-permalink: users/françois-xavier_lamure_tardieu
+redirect_from:
+  - /users/françois-xavier_lamure_tardieu
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/frederic-bonifas.md
+++ b/_people/frederic-bonifas.md
@@ -1,7 +1,8 @@
 ---
 title: Frederic Bonifas
 date: 2014-09-30 03:22:00 Z
-permalink: users/frederic_bonifas
+redirect_from:
+  - /users/frederic_bonifas
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/frederic-moine.md
+++ b/_people/frederic-moine.md
@@ -1,7 +1,8 @@
 ---
 title: Frederic Moine
 date: 2014-09-30 03:23:00 Z
-permalink: users/frederic_moine
+redirect_from:
+  - /users/frederic_moine
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/geoffrey-kateregga.md
+++ b/_people/geoffrey-kateregga.md
@@ -1,7 +1,8 @@
 ---
 title: Geoffrey Kateregga
 date: 2015-03-24 06:22:00 Z
-permalink: users/geoffrey_kateregga
+redirect_from:
+  - /users/geoffrey_kateregga
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-256-1454138810.jpg
 Member Type:
   Is Staff: true

--- a/_people/gertrude-trudy-hope-namitala.md
+++ b/_people/gertrude-trudy-hope-namitala.md
@@ -1,7 +1,8 @@
 ---
 title: Gertrude (Trudy Hope) Namitala
 date: 2017-02-28 01:49:00 Z
-permalink: users/gertrude_(trudy_hope)_namitala
+redirect_from:
+  - /users/gertrude_(trudy_hope)_namitala
 Member Type:
   Is Voting Member: true
 Working Group:

--- a/_people/hameed-tasal.md
+++ b/_people/hameed-tasal.md
@@ -1,7 +1,8 @@
 ---
 title: Hameed Tasal
 date: 2011-10-19 01:09:00 Z
-permalink: users/hameed_tasal
+redirect_from:
+  - /users/hameed_tasal
 Member Type:
   Is Voting Member: true
 Working Group:

--- a/_people/harry-mahardhika-machmud.md
+++ b/_people/harry-mahardhika-machmud.md
@@ -1,7 +1,8 @@
 ---
 title: Harry Mahardhika Machmud
 date: 2016-06-15 03:26:00 Z
-permalink: users/harry_mahardhika_machmud
+redirect_from:
+  - /users/harry_mahardhika_machmud
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-336-1475208816.jpg
 Member Type:
   Is Staff: true

--- a/_people/harry-wood.md
+++ b/_people/harry-wood.md
@@ -1,7 +1,8 @@
 ---
 title: Harry Wood
 date: 2010-08-03 16:09:00 Z
-permalink: users/harry_wood
+redirect_from:
+  - /users/harry_wood
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-11-1411586463.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/hawa-adinani.md
+++ b/_people/hawa-adinani.md
@@ -1,6 +1,7 @@
 ---
 title: Hawa Adinani
 date: 2017-11-16 21:13:40 Z
-permalink: users/hawa_adinani
+redirect_from:
+  - /users/hawa_adinani
 ---
 

--- a/_people/heather-leson.md
+++ b/_people/heather-leson.md
@@ -1,7 +1,8 @@
 ---
 title: Heather Leson
 date: 2013-12-01 16:39:00 Z
-permalink: users/heather_leson
+redirect_from:
+  - /users/heather_leson
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-70-1411583393.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/humberto-yances.md
+++ b/_people/humberto-yances.md
@@ -1,7 +1,8 @@
 ---
 title: Humberto Yances
 date: 2014-09-30 03:25:18 Z
-permalink: users/humberto_yances
+redirect_from:
+  - /users/humberto_yances
 Working Group:
 - Fundraising
 - Training

--- a/_people/innocent-maholi.md
+++ b/_people/innocent-maholi.md
@@ -1,7 +1,8 @@
 ---
 title: Innocent Maholi
 date: 2017-11-13 22:44:00 Z
-permalink: users/innocent_maholi
+redirect_from:
+  - /users/innocent_maholi
 Member Type:
   Is Staff: true
   Is Voting Member: true

--- a/_people/ismaila-seye.md
+++ b/_people/ismaila-seye.md
@@ -1,7 +1,8 @@
 ---
 title: Ismaila SEYE
 date: 2015-06-04 19:52:00 Z
-permalink: users/ismaila_seye
+redirect_from:
+  - /users/ismaila_seye
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-296-1433503071.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/ivan-gayton.md
+++ b/_people/ivan-gayton.md
@@ -1,7 +1,8 @@
 ---
 title: Ivan Gayton
 date: 2017-08-15 19:37:00 Z
-permalink: users/ivan_gayton
+redirect_from:
+  - /users/ivan_gayton
 Member Type:
   Is Staff: true
 Country: Tanzania

--- a/_people/ivn-snchez-ortega.md
+++ b/_people/ivn-snchez-ortega.md
@@ -1,7 +1,8 @@
 ---
 title: Iván Sánchez Ortega
 date: 2010-11-17 14:15:00 Z
-permalink: users/iván_sánchez_ortega
+redirect_from:
+  - /users/iván_sánchez_ortega
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-12-1432072766.png
 Member Type:
   Is Voting Member: true

--- a/_people/jaakko-helleranta.md
+++ b/_people/jaakko-helleranta.md
@@ -1,7 +1,8 @@
 ---
 title: Jaakko Helleranta
 date: 2013-03-22 14:22:00 Z
-permalink: users/jaakko_helleranta_
+redirect_from:
+  - /users/jaakko_helleranta_
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-52-1411584364.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/janet-chapman.md
+++ b/_people/janet-chapman.md
@@ -1,7 +1,8 @@
 ---
 title: Janet Chapman
 date: 2017-02-28 13:54:00 Z
-permalink: users/janet_chapman
+redirect_from:
+  - /users/janet_chapman
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-363-1488291554.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/jean-bully-prophete.md
+++ b/_people/jean-bully-prophete.md
@@ -1,7 +1,8 @@
 ---
 title: Jean Bully PROPHETE
 date: 2016-01-11 23:24:00 Z
-permalink: users/jean_bully_prophete
+redirect_from:
+  - /users/jean_bully_prophete
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-314-1452607634.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/jean-guilhem-cailton.md
+++ b/_people/jean-guilhem-cailton.md
@@ -1,7 +1,8 @@
 ---
 title: Jean-Guilhem Cailton
 date: 2012-04-14 18:41:00 Z
-permalink: users/jean-guilhem_cailton
+redirect_from:
+  - /users/jean-guilhem_cailton
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/jean-marie-mancabou.md
+++ b/_people/jean-marie-mancabou.md
@@ -1,7 +1,8 @@
 ---
 title: Jean Marie MANCABOU
 date: 2015-06-04 19:53:00 Z
-permalink: users/jean_marie_mancabou
+redirect_from:
+  - /users/jean_marie_mancabou
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-297-1433841747.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/jeff-haack.md
+++ b/_people/jeff-haack.md
@@ -1,7 +1,8 @@
 ---
 title: Jeff Haack
 date: 2011-07-17 07:39:00 Z
-permalink: users/jeff_haack
+redirect_from:
+  - /users/jeff_haack
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-18-1432371273.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/jessica-beutler.md
+++ b/_people/jessica-beutler.md
@@ -1,7 +1,8 @@
 ---
 title: Jessica Beutler
 date: 2017-04-25 16:47:24 Z
-permalink: users/jessica_beutler
+redirect_from:
+  - /users/jessica_beutler
 Member Type:
   Is Staff: true
 ---

--- a/_people/jessica-canepa.md
+++ b/_people/jessica-canepa.md
@@ -1,7 +1,8 @@
 ---
 title: Jessica Canepa
 date: 2014-12-28 21:34:46 Z
-permalink: users/jessica_canepa
+redirect_from:
+  - /users/jessica_canepa
 Country: United States
 ---
 

--- a/_people/john-crowley.md
+++ b/_people/john-crowley.md
@@ -1,7 +1,8 @@
 ---
 title: John Crowley
 date: 2012-05-18 14:33:00 Z
-permalink: users/john_crowley
+redirect_from:
+  - /users/john_crowley
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/jorieke-vyncke.md
+++ b/_people/jorieke-vyncke.md
@@ -1,7 +1,8 @@
 ---
 title: Jorieke Vyncke
 date: 2014-03-30 01:28:00 Z
-permalink: users/jorieke_vyncke
+redirect_from:
+  - /users/jorieke_vyncke
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-79-1432475599.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/joseph-reeves.md
+++ b/_people/joseph-reeves.md
@@ -1,7 +1,8 @@
 ---
 title: Joseph Reeves
 date: 2012-09-24 01:57:00 Z
-permalink: users/joseph_reeves
+redirect_from:
+  - /users/joseph_reeves
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-45-1412130672.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/julio-costa-zambelli.md
+++ b/_people/julio-costa-zambelli.md
@@ -1,7 +1,8 @@
 ---
 title: Julio Costa Zambelli
 date: 2014-09-30 03:27:00 Z
-permalink: users/julio_costa_zambelli
+redirect_from:
+  - /users/julio_costa_zambelli
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-222-1432073168.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/kate-chapman.md
+++ b/_people/kate-chapman.md
@@ -1,7 +1,8 @@
 ---
 title: Kate Chapman
 date: 2010-05-24 15:42:00 Z
-permalink: users/kate_chapman
+redirect_from:
+  - /users/kate_chapman
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-5-1412307645.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/katie-filbert.md
+++ b/_people/katie-filbert.md
@@ -1,7 +1,8 @@
 ---
 title: Katie Filbert
 date: 2014-09-30 03:22:00 Z
-permalink: users/katie_filbert
+redirect_from:
+  - /users/katie_filbert
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/katja-ulbert.md
+++ b/_people/katja-ulbert.md
@@ -1,7 +1,8 @@
 ---
 title: Katja Ulbert
 date: 2015-05-25 17:50:00 Z
-permalink: users/katja_ulbert
+redirect_from:
+  - /users/katja_ulbert
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-283-1440077668.jpg
 Member Type:
   Is Staff: true

--- a/_people/kiggudde-deogratias.md
+++ b/_people/kiggudde-deogratias.md
@@ -1,6 +1,7 @@
 ---
 title: Kiggudde Deogratias
 date: 2017-05-03 20:43:18 Z
-permalink: users/kiggudde_deogratias
+redirect_from:
+  - /users/kiggudde_deogratias
 ---
 

--- a/_people/kristen-egermeier.md
+++ b/_people/kristen-egermeier.md
@@ -1,7 +1,8 @@
 ---
 title: Kristen Egermeier
 date: 2012-09-20 00:15:00 Z
-permalink: users/kristen_egermeier
+redirect_from:
+  - /users/kristen_egermeier
 Member Type:
   Is Staff: false
 Working Group:

--- a/_people/kuo-yu-slayer-chuang.md
+++ b/_people/kuo-yu-slayer-chuang.md
@@ -1,7 +1,8 @@
 ---
 title: Kuo-Yu "slayer" Chuang
 date: 2016-01-11 23:33:00 Z
-permalink: users/kuo_yu_slayer_chuang
+redirect_from:
+  - /users/kuo_yu_slayer_chuang
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-317-1452565583.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/leonard-doyle.md
+++ b/_people/leonard-doyle.md
@@ -1,7 +1,8 @@
 ---
 title: Leonard Doyle
 date: 2014-09-30 03:27:00 Z
-permalink: users/leonard_doyle
+redirect_from:
+  - /users/leonard_doyle
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/lionel-riviere.md
+++ b/_people/lionel-riviere.md
@@ -1,6 +1,7 @@
 ---
 title: Lionel Riviere
 date: 2017-05-16 18:47:15 Z
-permalink: users/lionel_riviere
+redirect_from:
+  - /users/lionel_riviere
 ---
 

--- a/_people/lisa-sweeney.md
+++ b/_people/lisa-sweeney.md
@@ -1,7 +1,8 @@
 ---
 title: Lisa Sweeney
 date: 2014-09-30 03:28:00 Z
-permalink: users/lisa_sweeney
+redirect_from:
+  - /users/lisa_sweeney
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/louino-robillard.md
+++ b/_people/louino-robillard.md
@@ -1,7 +1,8 @@
 ---
 title: Louino Robillard
 date: 2015-06-04 19:54:00 Z
-permalink: users/louino_robillard
+redirect_from:
+  - /users/louino_robillard
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/mamadou-bassirou-thiam.md
+++ b/_people/mamadou-bassirou-thiam.md
@@ -1,7 +1,8 @@
 ---
 title: Mamadou Bassirou THIAM
 date: 2014-09-30 03:28:00 Z
-permalink: users/mamadou_bassirou_thiam
+redirect_from:
+  - /users/mamadou_bassirou_thiam
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-225-1412071874.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/maning-sambale.md
+++ b/_people/maning-sambale.md
@@ -1,7 +1,8 @@
 ---
 title: Maning Sambale
 date: 2012-01-25 07:00:00 Z
-permalink: users/maning_sambale
+redirect_from:
+  - /users/maning_sambale
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-22-1412247363.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/marc-mashawu.md
+++ b/_people/marc-mashawu.md
@@ -1,7 +1,8 @@
 ---
 title: Marc Mashawu
 date: 2017-02-28 13:56:00 Z
-permalink: users/marc_mashawu
+redirect_from:
+  - /users/marc_mashawu
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-365-1488292094.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/marco-minghini.md
+++ b/_people/marco-minghini.md
@@ -1,7 +1,8 @@
 ---
 title: Marco Minghini
 date: 2017-02-28 13:55:00 Z
-permalink: users/marco_minghini
+redirect_from:
+  - /users/marco_minghini
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-364-1488489604.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/maria-longley.md
+++ b/_people/maria-longley.md
@@ -1,7 +1,8 @@
 ---
 title: Maria Longley
 date: 2017-02-28 14:18:53 Z
-permalink: users/maria_longley
+redirect_from:
+  - /users/maria_longley
 Project:
 - Missing Maps
 Country: United Kingdom

--- a/_people/mark-cupitt.md
+++ b/_people/mark-cupitt.md
@@ -1,7 +1,8 @@
 ---
 title: Mark Cupitt
 date: 2015-02-18 16:15:19 Z
-permalink: users/mark_cupitt
+redirect_from:
+  - /users/mark_cupitt
 Working Group:
 - Activation
 - Technical

--- a/_people/martin-dittus.md
+++ b/_people/martin-dittus.md
@@ -1,7 +1,8 @@
 ---
 title: Martin Dittus
 date: 2017-02-28 14:07:00 Z
-permalink: users/martin_dittus
+redirect_from:
+  - /users/martin_dittus
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-374-1488815016.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/martin-noblecourt.md
+++ b/_people/martin-noblecourt.md
@@ -1,7 +1,8 @@
 ---
 title: Martin Noblecourt
 date: 2017-02-28 14:24:00 Z
-permalink: users/martin_noblecourt
+redirect_from:
+  - /users/martin_noblecourt
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/matthew-gibb.md
+++ b/_people/matthew-gibb.md
@@ -1,7 +1,8 @@
 ---
 title: Matthew Gibb
 date: 2017-02-28 14:23:00 Z
-permalink: users/matthew_gibb
+redirect_from:
+  - /users/matthew_gibb
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-383-1488293342.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/melanie-eckle.md
+++ b/_people/melanie-eckle.md
@@ -1,7 +1,8 @@
 ---
 title: Melanie Eckle
 date: 2017-02-28 14:26:00 Z
-permalink: users/melanie_eckle
+redirect_from:
+  - /users/melanie_eckle
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-387-1489498023.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/mhairi-ohara.md
+++ b/_people/mhairi-ohara.md
@@ -1,7 +1,8 @@
 ---
 title: Mhairi O'Hara
 date: 2015-02-12 14:16:00 Z
-permalink: users/mhairi_o'hara
+redirect_from:
+  - /users/mhairi_o'hara
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-252-1461153821.png
 Member Type:
   Is Staff: true

--- a/_people/michael-heimeier.md
+++ b/_people/michael-heimeier.md
@@ -1,7 +1,8 @@
 ---
 title: Michael Heißmeier
 date: 2016-01-11 23:40:00 Z
-permalink: users/michael_heißmeier
+redirect_from:
+  - /users/michael_heißmeier
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-322-1452592487.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/michael-thompson.md
+++ b/_people/michael-thompson.md
@@ -1,7 +1,8 @@
 ---
 title: Michael Thompson
 date: 2017-02-28 14:06:00 Z
-permalink: users/michael_thompson
+redirect_from:
+  - /users/michael_thompson
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/mike-mccaffrey.md
+++ b/_people/mike-mccaffrey.md
@@ -1,7 +1,8 @@
 ---
 title: Mike McCaffrey
 date: 2012-02-03 06:44:09 Z
-permalink: users/mike_mccaffrey
+redirect_from:
+  - /users/mike_mccaffrey
 Country: United States
 ---
 

--- a/_people/mikel-maron.md
+++ b/_people/mikel-maron.md
@@ -1,7 +1,8 @@
 ---
 title: Mikel Maron
 date: 2010-05-24 15:40:00 Z
-permalink: users/mikel_maron
+redirect_from:
+  - /users/mikel_maron
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-3-1411582700.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/miriam-gonzalez.md
+++ b/_people/miriam-gonzalez.md
@@ -1,7 +1,8 @@
 ---
 title: Miriam Gonzalez
 date: 2017-02-28 14:06:00 Z
-permalink: users/miriam_gonzalez
+redirect_from:
+  - /users/miriam_gonzalez
 Member Type:
   Is Voting Member: true
 Project:

--- a/_people/nama-raj-budhathoki.md
+++ b/_people/nama-raj-budhathoki.md
@@ -1,7 +1,8 @@
 ---
 title: Nama Raj Budhathoki
 date: 2014-02-03 11:01:00 Z
-permalink: users/nama_raj_budhathoki
+redirect_from:
+  - /users/nama_raj_budhathoki
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-78-1430499781.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/nate-smith.md
+++ b/_people/nate-smith.md
@@ -1,7 +1,8 @@
 ---
 title: Nate Smith
 date: 2016-01-11 23:27:00 Z
-permalink: users/nate_smith
+redirect_from:
+  - /users/nate_smith
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-315-1464686481.png
 Member Type:
   Is Staff: true

--- a/_people/nathalie-sidibe.md
+++ b/_people/nathalie-sidibe.md
@@ -1,7 +1,8 @@
 ---
 title: Nathalie Sidibe
 date: 2017-02-28 14:19:00 Z
-permalink: users/nathalie_sidibe
+redirect_from:
+  - /users/nathalie_sidibe
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-381-1498331929.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/nick-allen.md
+++ b/_people/nick-allen.md
@@ -1,7 +1,8 @@
 ---
 title: Nick Allen
 date: 2015-06-04 19:56:00 Z
-permalink: users/nick_allen
+redirect_from:
+  - /users/nick_allen
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-299-1433452153.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/nicolas-chavent.md
+++ b/_people/nicolas-chavent.md
@@ -1,7 +1,8 @@
 ---
 title: Nicolas Chavent
 date: 2010-05-24 15:41:00 Z
-permalink: users/nicolas_chavent
+redirect_from:
+  - /users/nicolas_chavent
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/nuala-cowan.md
+++ b/_people/nuala-cowan.md
@@ -1,7 +1,8 @@
 ---
 title: Nuala Cowan
 date: 2015-06-04 19:56:00 Z
-permalink: users/nuala_cowan
+redirect_from:
+  - /users/nuala_cowan
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/orsolya-jenei.md
+++ b/_people/orsolya-jenei.md
@@ -1,7 +1,8 @@
 ---
 title: Orsolya Jenei
 date: 2015-06-04 19:57:00 Z
-permalink: users/orsolya_jenei
+redirect_from:
+  - /users/orsolya_jenei
 Member Type:
   Is Voting Member: true
 Working Group:

--- a/_people/patricia-solis.md
+++ b/_people/patricia-solis.md
@@ -1,7 +1,8 @@
 ---
 title: Patricia Solis
 date: 2017-02-28 14:17:00 Z
-permalink: users/patricia_solis
+redirect_from:
+  - /users/patricia_solis
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-379-1488291994.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/paul-stewart.md
+++ b/_people/paul-stewart.md
@@ -1,7 +1,8 @@
 ---
 title: Paul Stewart
 date: 2016-02-19 16:45:52 Z
-permalink: users/paul_stewart
+redirect_from:
+  - /users/paul_stewart
 Working Group:
 - Community
 - Technical

--- a/_people/paul-uithol.md
+++ b/_people/paul-uithol.md
@@ -1,7 +1,8 @@
 ---
 title: Paul Uithol
 date: 2015-07-14 16:44:48 Z
-permalink: users/paul_uithol
+redirect_from:
+  - /users/paul_uithol
 Working Group:
 - Communications
 Project:

--- a/_people/pete-masters.md
+++ b/_people/pete-masters.md
@@ -1,7 +1,8 @@
 ---
 title: Pete Masters
 date: 2015-04-30 11:55:00 Z
-permalink: users/pete_masters
+redirect_from:
+  - /users/pete_masters
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-258-1433935659.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/pierre-bland.md
+++ b/_people/pierre-bland.md
@@ -1,7 +1,8 @@
 ---
 title: Pierre Béland
 date: 2012-02-03 17:23:00 Z
-permalink: users/pierre_béland
+redirect_from:
+  - /users/pierre_béland
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-25-1433014712.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/pierre-giraud.md
+++ b/_people/pierre-giraud.md
@@ -1,7 +1,8 @@
 ---
 title: Pierre GIRAUD
 date: 2014-09-30 03:30:00 Z
-permalink: users/pierre_giraud
+redirect_from:
+  - /users/pierre_giraud
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-229-1432107341.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/pierre-mirlesse.md
+++ b/_people/pierre-mirlesse.md
@@ -1,7 +1,8 @@
 ---
 title: Pierre Mirlesse
 date: 2015-06-26 14:56:00 Z
-permalink: users/pierre_mirlesse
+redirect_from:
+  - /users/pierre_mirlesse
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-309-1437746541.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/pratik-yadav.md
+++ b/_people/pratik-yadav.md
@@ -1,7 +1,8 @@
 ---
 title: Pratik Yadav
 date: 2017-02-28 14:08:00 Z
-permalink: users/pratik_yadav
+redirect_from:
+  - /users/pratik_yadav
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-375-1488433273.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/r-l-kartika-sari.md
+++ b/_people/r-l-kartika-sari.md
@@ -1,7 +1,8 @@
 ---
 title: R.L.Kartika Sari
 date: 2016-06-15 03:43:47 Z
-permalink: users/r.l.kartika_sari
+redirect_from:
+  - /users/r.l.kartika_sari
 Country: Indonesia
 Social Media (Full URL):
   LinkedIn: https://id.linkedin.com/in/ika-rahmat-b79498121

--- a/_people/rachel-levine.md
+++ b/_people/rachel-levine.md
@@ -1,7 +1,8 @@
 ---
 title: Rachel Levine
 date: 2017-02-28 13:59:00 Z
-permalink: users/rachel_levine
+redirect_from:
+  - /users/rachel_levine
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-367-1488393062.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/rachel-vannice.md
+++ b/_people/rachel-vannice.md
@@ -1,7 +1,8 @@
 ---
 title: Rachel VanNice
 date: 2016-11-08 21:00:59 Z
-permalink: users/rachel_vannice
+redirect_from:
+  - /users/rachel_vannice
 Working Group:
 - Fundraising
 - Communications

--- a/_people/rafael-vila-coya.md
+++ b/_people/rafael-vila-coya.md
@@ -1,7 +1,8 @@
 ---
 title: Rafael Ávila Coya
 date: 2014-09-30 03:30:00 Z
-permalink: users/rafael_Ávila_coya
+redirect_from:
+  - /users/rafael_Ávila_coya
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-231-1432071490.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/ralph-aytoun.md
+++ b/_people/ralph-aytoun.md
@@ -1,7 +1,8 @@
 ---
 title: Ralph Aytoun
 date: 2017-02-28 13:58:00 Z
-permalink: users/ralph_aytoun
+redirect_from:
+  - /users/ralph_aytoun
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-366-1488296375.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/ranie-dwi-anugrah.md
+++ b/_people/ranie-dwi-anugrah.md
@@ -1,7 +1,8 @@
 ---
 title: Ranie Dwi Anugrah
 date: 2016-06-15 03:14:00 Z
-permalink: users/ranie_dwi_anugrah
+redirect_from:
+  - /users/ranie_dwi_anugrah
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-335-1465965209.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/rebecca-firth.md
+++ b/_people/rebecca-firth.md
@@ -1,7 +1,8 @@
 ---
 title: Rebecca Firth
 date: 2016-12-21 15:24:56 Z
-permalink: users/rebecca_firth
+redirect_from:
+  - /users/rebecca_firth
 Working Group:
 - Fundraising
 - Communications

--- a/_people/rob-baker.md
+++ b/_people/rob-baker.md
@@ -1,7 +1,8 @@
 ---
 title: Rob Baker
 date: 2011-03-17 04:53:00 Z
-permalink: users/rob_baker
+redirect_from:
+  - /users/rob_baker
 Member Type:
   Is Voting Member: true
 Working Group:

--- a/_people/robert-banick.md
+++ b/_people/robert-banick.md
@@ -1,7 +1,8 @@
 ---
 title: Robert Banick
 date: 2014-09-30 03:31:00 Z
-permalink: users/robert_banick
+redirect_from:
+  - /users/robert_banick
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-232-1434983751.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/robert-soden.md
+++ b/_people/robert-soden.md
@@ -1,7 +1,8 @@
 ---
 title: Robert Soden
 date: 2014-09-30 03:31:00 Z
-permalink: users/robert_soden
+redirect_from:
+  - /users/robert_soden
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/roderic-bera.md
+++ b/_people/roderic-bera.md
@@ -1,6 +1,7 @@
 ---
 title: Roderic Bera
 date: 2014-09-30 03:31:39 Z
-permalink: users/roderic_bera
+redirect_from:
+  - /users/roderic_bera
 ---
 

--- a/_people/rodolfo-wilhelmy.md
+++ b/_people/rodolfo-wilhelmy.md
@@ -1,7 +1,8 @@
 ---
 title: Rodolfo Wilhelmy
 date: 2016-01-11 23:34:43 Z
-permalink: users/rodolfo_wilhelmy
+redirect_from:
+  - /users/rodolfo_wilhelmy
 Country: Mexico
 Social Media (Full URL):
   LinkedIn: https://www.linkedin.com/in/rodowi

--- a/_people/rupert-allan.md
+++ b/_people/rupert-allan.md
@@ -1,7 +1,8 @@
 ---
 title: Rupert Allan
 date: 2017-10-27 18:18:06 Z
-permalink: users/rupert_allan
+redirect_from:
+  - /users/rupert_allan
 Working Group:
 - Community
 - Communications

--- a/_people/russell-deffner.md
+++ b/_people/russell-deffner.md
@@ -1,7 +1,8 @@
 ---
 title: Russell Deffner
 date: 2013-12-01 16:40:00 Z
-permalink: users/russell_deffner
+redirect_from:
+  - /users/russell_deffner
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-71-1515514638.jpg
 Member Type:
   Is Staff: true

--- a/_people/sajjad-anwar.md
+++ b/_people/sajjad-anwar.md
@@ -1,7 +1,8 @@
 ---
 title: Sajjad Anwar
 date: 2016-01-11 23:39:00 Z
-permalink: users/sajjad_anwar
+redirect_from:
+  - /users/sajjad_anwar
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-321-1452658791.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/sam-larsen.md
+++ b/_people/sam-larsen.md
@@ -1,7 +1,8 @@
 ---
 title: Sam Larsen
 date: 2014-09-30 03:32:00 Z
-permalink: users/sam_larsen
+redirect_from:
+  - /users/sam_larsen
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/samuel-olubunmi-aiyeoribe.md
+++ b/_people/samuel-olubunmi-aiyeoribe.md
@@ -1,7 +1,8 @@
 ---
 title: Samuel Olubunmi Aiyeoribe
 date: 2016-01-11 23:28:00 Z
-permalink: users/samuel_olubunmi_aiyeoribe
+redirect_from:
+  - /users/samuel_olubunmi_aiyeoribe
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-316-1452585655.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/satoshi-iida.md
+++ b/_people/satoshi-iida.md
@@ -1,7 +1,8 @@
 ---
 title: Satoshi IIDA
 date: 2014-03-31 14:34:00 Z
-permalink: users/satoshi_iida
+redirect_from:
+  - /users/satoshi_iida
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-80-1432090557.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/schneider-remy.md
+++ b/_people/schneider-remy.md
@@ -1,7 +1,8 @@
 ---
 title: Schneider Remy
 date: 2017-02-28 14:09:00 Z
-permalink: users/schneider_remy
+redirect_from:
+  - /users/schneider_remy
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/schuyler-erle.md
+++ b/_people/schuyler-erle.md
@@ -1,7 +1,8 @@
 ---
 title: Schuyler Erle
 date: 2011-09-10 20:25:00 Z
-permalink: users/schuyler_erle
+redirect_from:
+  - /users/schuyler_erle
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-8-1411583908.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/sebastien-pierrel.md
+++ b/_people/sebastien-pierrel.md
@@ -1,7 +1,8 @@
 ---
 title: Sebastien Pierrel
 date: 2014-09-30 03:32:00 Z
-permalink: users/sebastien_pierrel
+redirect_from:
+  - /users/sebastien_pierrel
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/sheila-amalia.md
+++ b/_people/sheila-amalia.md
@@ -1,7 +1,8 @@
 ---
 title: Sheila Amalia
 date: 2016-12-15 19:22:20 Z
-permalink: users/sheila_amalia
+redirect_from:
+  - /users/sheila_amalia
 Country: Indonesia
 Member Type:
   Is Staff: true

--- a/_people/shoaib-burq.md
+++ b/_people/shoaib-burq.md
@@ -1,7 +1,8 @@
 ---
 title: Shoaib Burq
 date: 2015-06-04 19:58:00 Z
-permalink: users/shoaib_burq
+redirect_from:
+  - /users/shoaib_burq
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/shu-higashi.md
+++ b/_people/shu-higashi.md
@@ -1,7 +1,8 @@
 ---
 title: Shu Higashi
 date: 2014-09-30 03:24:00 Z
-permalink: users/shu_higashi
+redirect_from:
+  - /users/shu_higashi
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-218-1432862914.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/sophie-lafayette.md
+++ b/_people/sophie-lafayette.md
@@ -1,7 +1,8 @@
 ---
 title: Sophie Lafayette
 date: 2015-07-14 16:45:43 Z
-permalink: users/sophie_lafayette
+redirect_from:
+  - /users/sophie_lafayette
 Project:
 - Dar Ramani Huria — Dar Open Map
 Country: Tanzania

--- a/_people/stephane-goldstein.md
+++ b/_people/stephane-goldstein.md
@@ -1,7 +1,8 @@
 ---
 title: Stephane Goldstein
 date: 2012-05-26 21:19:23 Z
-permalink: users/stephane_goldstein
+redirect_from:
+  - /users/stephane_goldstein
 Country: Brazil
 ---
 

--- a/_people/stephanie-skryzowski.md
+++ b/_people/stephanie-skryzowski.md
@@ -1,6 +1,7 @@
 ---
 title: Stephanie Skryzowski
 date: 2017-11-20 14:29:02 Z
-permalink: users/stephanie_skryzowski
+redirect_from:
+  - /users/stephanie_skryzowski
 ---
 

--- a/_people/stephen-little.md
+++ b/_people/stephen-little.md
@@ -1,7 +1,8 @@
 ---
 title: Stephen Little
 date: 2017-05-03 20:39:10 Z
-permalink: users/stephen_little
+redirect_from:
+  - /users/stephen_little
 Country: United States
 ---
 

--- a/_people/steven-bukulu.md
+++ b/_people/steven-bukulu.md
@@ -1,7 +1,8 @@
 ---
 title: Steven Bukulu
 date: 2015-03-24 05:24:00 Z
-permalink: users/steven_bukulu
+redirect_from:
+  - /users/steven_bukulu
 Working Group:
 - Training
 - Communications

--- a/_people/steven-johnson.md
+++ b/_people/steven-johnson.md
@@ -1,7 +1,8 @@
 ---
 title: Steven Johnson
 date: 2015-05-28 19:38:41 Z
-permalink: users/steven_johnson
+redirect_from:
+  - /users/steven_johnson
 Working Group:
 - Training
 - Activation

--- a/_people/stphane-henriod.md
+++ b/_people/stphane-henriod.md
@@ -1,7 +1,8 @@
 ---
 title: Stéphane Henriod
 date: 2013-02-17 09:19:00 Z
-permalink: users/stéphane_henriod
+redirect_from:
+  - /users/stéphane_henriod
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-50-1432127648.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/sverin-mnard.md
+++ b/_people/sverin-mnard.md
@@ -1,7 +1,8 @@
 ---
 title: Séverin Ménard
 date: 2011-07-08 10:05:00 Z
-permalink: users/séverin_ménard
+redirect_from:
+  - /users/séverin_ménard
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-15-1411584466.jpg
 Member Type:
   Is Board Member: false

--- a/_people/taichi-furuhashi.md
+++ b/_people/taichi-furuhashi.md
@@ -1,7 +1,8 @@
 ---
 title: Taichi Furuhashi
 date: 2015-06-04 19:59:00 Z
-permalink: users/taichi_furuhashi
+redirect_from:
+  - /users/taichi_furuhashi
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-303-1433533133.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/tasauf-a-baki-billah-ribin.md
+++ b/_people/tasauf-a-baki-billah-ribin.md
@@ -1,7 +1,8 @@
 ---
 title: Tasauf A Baki Billah (Ribin)
 date: 2017-02-28 14:02:00 Z
-permalink: users/tasauf_a_baki_billah_(ribin)
+redirect_from:
+  - /users/tasauf_a_baki_billah_(ribin)
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-369-1488295145.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/tevfik-suha-ulgen.md
+++ b/_people/tevfik-suha-ulgen.md
@@ -1,7 +1,8 @@
 ---
 title: Tevfik Suha Ulgen
 date: 2014-09-30 03:33:00 Z
-permalink: users/tevfik_suha_ulgen
+redirect_from:
+  - /users/tevfik_suha_ulgen
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-241-1432790290.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/tim-mcnamara.md
+++ b/_people/tim-mcnamara.md
@@ -1,7 +1,8 @@
 ---
 title: Tim McNamara
 date: 2014-09-30 03:29:00 Z
-permalink: users/tim_mcnamara
+redirect_from:
+  - /users/tim_mcnamara
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/tim-waters.md
+++ b/_people/tim-waters.md
@@ -1,7 +1,8 @@
 ---
 title: Tim Waters
 date: 2014-09-30 03:33:00 Z
-permalink: users/tim_waters
+redirect_from:
+  - /users/tim_waters
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-239-1432131310.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/todd-huffman.md
+++ b/_people/todd-huffman.md
@@ -1,7 +1,8 @@
 ---
 title: Todd Huffman
 date: 2010-06-19 00:54:00 Z
-permalink: users/todd_huffman
+redirect_from:
+  - /users/todd_huffman
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/tom-buckley.md
+++ b/_people/tom-buckley.md
@@ -1,7 +1,8 @@
 ---
 title: Tom Buckley
 date: 2014-09-30 03:19:00 Z
-permalink: users/tom_buckley
+redirect_from:
+  - /users/tom_buckley
 Member Type:
   Is Voting Member: true
 Country: United States

--- a/_people/trevor-ellerman.md
+++ b/_people/trevor-ellerman.md
@@ -1,7 +1,8 @@
 ---
 title: Trevor Ellerman
 date: 2010-06-19 00:53:00 Z
-permalink: users/trevor_ellerman
+redirect_from:
+  - /users/trevor_ellerman
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/tyler-radford.md
+++ b/_people/tyler-radford.md
@@ -1,7 +1,8 @@
 ---
 title: Tyler Radford
 date: 2015-05-01 15:58:28 Z
-permalink: users/tyler_radford
+redirect_from:
+  - /users/tyler_radford
 Working Group:
 - Fundraising
 - Communications

--- a/_people/usman-latif.md
+++ b/_people/usman-latif.md
@@ -1,7 +1,8 @@
 ---
 title: Usman Latif
 date: 2017-02-28 14:03:00 Z
-permalink: users/usman_latif
+redirect_from:
+  - /users/usman_latif
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/vasanthi-hargyono.md
+++ b/_people/vasanthi-hargyono.md
@@ -1,7 +1,8 @@
 ---
 title: Vasanthi Hargyono
 date: 2011-07-15 15:34:00 Z
-permalink: users/vasanthi_hargyono
+redirect_from:
+  - /users/vasanthi_hargyono
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-17-1456906866.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/violaine-doutreleau.md
+++ b/_people/violaine-doutreleau.md
@@ -1,7 +1,8 @@
 ---
 title: Violaine Doutreleau
 date: 2017-02-28 14:23:00 Z
-permalink: users/violaine_doutreleau
+redirect_from:
+  - /users/violaine_doutreleau
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/vitor-george.md
+++ b/_people/vitor-george.md
@@ -1,7 +1,8 @@
 ---
 title: Vitor George
 date: 2015-06-04 20:00:00 Z
-permalink: users/vitor_george
+redirect_from:
+  - /users/vitor_george
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-304-1434988965.jpg
 Member Type:
   Is Voting Member: true

--- a/_people/vivien-deparday.md
+++ b/_people/vivien-deparday.md
@@ -1,7 +1,8 @@
 ---
 title: Vivien Deparday
 date: 2015-06-04 20:01:00 Z
-permalink: users/vivien_deparday
+redirect_from:
+  - /users/vivien_deparday
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/will-skora.md
+++ b/_people/will-skora.md
@@ -1,7 +1,8 @@
 ---
 title: Will Skora
 date: 2012-05-26 21:17:00 Z
-permalink: users/will_skora
+redirect_from:
+  - /users/will_skora
 Member Type:
   Is Voting Member: true
 Working Group:

--- a/_people/wulansari-khairunisa.md
+++ b/_people/wulansari-khairunisa.md
@@ -1,7 +1,8 @@
 ---
 title: Wulansari Khairunisa
 date: 2017-02-28 14:00:00 Z
-permalink: users/wulansari_khairunisa
+redirect_from:
+  - /users/wulansari_khairunisa
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/yantisa-akhadi.md
+++ b/_people/yantisa-akhadi.md
@@ -1,7 +1,8 @@
 ---
 title: Yantisa Akhadi
 date: 2014-06-16 15:09:00 Z
-permalink: users/yantisa_akhadi
+redirect_from:
+  - /users/yantisa_akhadi
 Photo: http://hotwww.s3-website-us-east-1.amazonaws.com/files/old/pictures/picture-101-1432092398.jpg
 Member Type:
   Is Staff: true

--- a/_people/yohan-boniface.md
+++ b/_people/yohan-boniface.md
@@ -1,7 +1,8 @@
 ---
 title: Yohan Boniface
 date: 2013-03-22 14:21:00 Z
-permalink: users/yohan_boniface
+redirect_from:
+  - /users/yohan_boniface
 Member Type:
   Is Voting Member: true
 ---

--- a/_people/zacharia-muindi.md
+++ b/_people/zacharia-muindi.md
@@ -1,7 +1,8 @@
 ---
 title: Zacharia Muindi
 date: 2015-06-04 20:02:00 Z
-permalink: users/zacharia_muindi
+redirect_from:
+  - /users/zacharia_muindi
 Member Type:
   Is Voting Member: true
 ---


### PR DESCRIPTION
Adds `jekyll-redirect-from` plugin to redirect links related to "users". This switches to our model of people pages. 

Old links, `http://hotosm.org/users/kate_chapman` now are redirected to `http://hotosm.org/people/kate-chapman`