### PR TITLE
adjust impact area layout to match our work layout

### DIFF
--- a/_layouts/impact-area.html
+++ b/_layouts/impact-area.html
@@ -3,51 +3,21 @@ layout: default
 ---
 
 <div class="project-index">
-
-  <div class="project-map-area">
-
+  <div class="impact-map-area">
     <div id="map">
     </div>
 
     <div class="project-index-header" id="impact-areas-select">
       <div class="container">
         <h1 class="boxed" id="our-work-title">{{ page.title }}</h1>
-        <div class="impact-area-desc">
-          <span>{{ content }}<div class="hr"></div></span>
-        </div>
-      </div>
-
-      <div class="our-work-filters">
-
-        <div class="btn btn-primary btn-expand" id="expand-map-btn" onclick="expandMap()">See where we work</div>
-
       </div>
     </div>
-
-
-    <div class="our-work-filters hidden" id="regions-select">
-      <div class="btn btn-primary btn-close" id="close-map-btn" onclick="expandMap()">Exit map</div>
-      <div class="container">
-        <h6>
-          Choose region
-        </h6>
-        <div id="continents">
-          <a onClick="activateAfrica()" class="regions-link">Africa</a>
-          <a onClick="activateAsia()" class="regions-link">Asia</a>
-          <a onClick="activateEurope()" class="regions-link">Europe</a>
-          <a onClick="activateNAmerica()" class="regions-link">North America</a>
-          <a onClick="activateSAmerica()" class="regions-link">South America</a>
-          <a onClick="activateOceania()" class="regions-link">Oceania</a>
-        </div>
-        <div id="countries-list">
-        </div>
-      </div>
-    </div>
-
-
+  </div>
+  <div class="impact-area-desc">
+    <span>{{ content }}<div class="hr"></div></span>
   </div>
 
-  <div id="our-work-projects" class="container">
+  <div id="impact-projects" class="container">
 
     <h6>Highlighted Projects</h6>
 
@@ -89,6 +59,6 @@ layout: default
   </div>
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.js'></script>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.css' rel='stylesheet' />
-  <script src="{{ "/js/our-work-map.js" | prepend: site.baseurl }}"></script>
+  <script src="{{ "/js/impact-areas-map.js" | prepend: site.baseurl }}"></script>
 
 </div>

--- a/_layouts/impact-area.html
+++ b/_layouts/impact-area.html
@@ -2,28 +2,54 @@
 layout: default
 ---
 
-<div class="project-index impact-area-item-index">
+<div class="project-index">
 
   <div class="project-map-area">
 
-    <div class="project-index-header">
+    <div id="map">
+    </div>
 
+    <div class="project-index-header" id="impact-areas-select">
       <div class="container">
-        <div><h1 class="boxed">{{ page.title }}</h1></div>
+        <h1 class="boxed" id="our-work-title">{{ page.title }}</h1>
         <div class="impact-area-desc">
           <span>{{ content }}<div class="hr"></div></span>
         </div>
       </div>
 
+      <div class="our-work-filters">
+
+        <div class="btn btn-primary btn-expand" id="expand-map-btn" onclick="expandMap()">See where we work</div>
+
+      </div>
     </div>
 
-    <span class="btn btn-primary btn-map">Explore Map</span>
+
+    <div class="our-work-filters hidden" id="regions-select">
+      <div class="btn btn-primary btn-close" id="close-map-btn" onclick="expandMap()">Exit map</div>
+      <div class="container">
+        <h6>
+          Choose region
+        </h6>
+        <div id="continents">
+          <a onClick="activateAfrica()" class="regions-link">Africa</a>
+          <a onClick="activateAsia()" class="regions-link">Asia</a>
+          <a onClick="activateEurope()" class="regions-link">Europe</a>
+          <a onClick="activateNAmerica()" class="regions-link">North America</a>
+          <a onClick="activateSAmerica()" class="regions-link">South America</a>
+          <a onClick="activateOceania()" class="regions-link">Oceania</a>
+        </div>
+        <div id="countries-list">
+        </div>
+      </div>
+    </div>
+
 
   </div>
 
-  <div class="container">
+  <div id="our-work-projects" class="container">
 
-    <h6>{{ page.title }} Projects</h6>
+    <h6>Highlighted Projects</h6>
 
     <div class="project-index-highlights">
 
@@ -44,7 +70,7 @@ layout: default
 
     <div class="hr-h"></div>
 
-    <h6>All Projects</h6>
+    <h6>All {{ page.title }} Projects</h6>
 
     <div class="project-index-all">
 
@@ -61,4 +87,8 @@ layout: default
     </div>
 
   </div>
+  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.js'></script>
+  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.css' rel='stylesheet' />
+  <script src="{{ "/js/our-work-map.js" | prepend: site.baseurl }}"></script>
+
 </div>

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -4,14 +4,11 @@ layout: default
 
 <div class="person-profile">
 
-
   <!--////////////////////////////////-->
   <!--//////// Person Header /////////-->
   <!--////////////////////////////////-->
 
-
   <header class="person-header">
-
     <div class="person-map-area" id="person-map-area">
       <div class="person-header-info">
         {% if page.Photo %}
@@ -27,9 +24,7 @@ layout: default
         </div>
       </div>
     </div>
-
   </header>
-
 
   <!--////////////////////////////////-->
   <!--///////// Person Body //////////-->

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -2258,6 +2258,13 @@ em {
   float: left;
 }
 
+.impact-map-area {
+  width: 100%;
+  height: 412px;
+  position: relative;
+}
+
+
 .project-map-area {
   height: 500px;
   width: 100%;
@@ -2461,6 +2468,7 @@ em {
 .impact-area-desc {
   display: grid;
   grid-template-columns: repeat(24, 1fr);
+  margin-bottom: 40px;
   span {
     background-color: $blue-dark;
     padding: 22px;

--- a/js/impact-areas-map.js
+++ b/js/impact-areas-map.js
@@ -1,0 +1,60 @@
+var countries = {};
+var projectCountries, memberCountries = [];
+
+fetch('/countries.json')
+  .then(function(response) {
+    return response.json();
+  })
+  .then(function(jsonData) {
+    countries = jsonData;
+    countriesList = Object.keys(countries);
+    projectCountries = countriesList.filter(function(item) {
+      return countries[item].hot_program || countries[item].community_program;
+    });
+    memberCountries = countriesList.filter(function(item) {
+      return countries[item].member && !projectCountries.includes(item);
+    });
+  }
+);
+
+mapboxgl.accessToken = 'pk.eyJ1IjoiaG90IiwiYSI6IlBtUmNiR1kifQ.dCS1Eu9DIRNZGktc24IwtA';
+var map = new mapboxgl.Map({
+  container: 'map',
+  logoPosition: 'bottom-right',
+  scrollZoom: false,
+  zoom: 1.25,
+  center: [0, 17],
+  style: 'mapbox://styles/hot/cjepk5hhz5o9w2rozqj353ut4'
+});
+
+map.on('load', function () {
+  map.addSource('countriesbetter', {
+    "type": "vector",
+    "url": "mapbox://hot.9fvp7us2"
+  });
+
+  map.addLayer({
+    "id": "project_countries",
+    "type": "fill",
+    "source": "countriesbetter",
+    "source-layer": "countriesbetter",
+    "minzoom": 0,
+    "maxzoom": 8,
+    "filter": ['in', 'name_low'].concat(projectCountries),
+    "paint": {
+      "fill-pattern": "lines-red-4",
+      "fill-outline-color": "#EFB4B4"
+    }
+  }, 'place-city-sm');
+
+  map.on('click', function(e) {
+    var features = map.queryRenderedFeatures(
+      [e.point.x, e.point.y],
+      {layers: ['project_countries']}
+    );
+    if (features.length) {
+      var country_name = features[0].properties.name_low.split(' ').join('-');
+      $(location).attr('href', '/where-we-work/' + country_name);
+    }
+  });
+});

--- a/js/member-map.js
+++ b/js/member-map.js
@@ -43,7 +43,6 @@ map.on('load', function() {
           padding: 10
         });
       }
-
     }
   );
 });


### PR DESCRIPTION
@brendangatens @willemarcel Not sure if this is the vision but here is a fix to the impact areas page so the map works similarly to the our work page. 

@brendangatens This doesn't factor for the updated style that you made for the impact area links on the our work page. Is that something you want to see here?

![fireshot capture 1 - humanitarian openst_ - http___localhost_4000_impact-areas_water-and-sanitation_](https://user-images.githubusercontent.com/796838/39425219-51b8ba10-4c72-11e8-8440-cd62970b02ef.png)
