### PR TITLE
update community, support programs, and working group urls

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ collections:
   working-groups:
     title: Working Groups
     output: true
+    permalink: "/community/working-groups/:path/"
 defaults:
 - scope:
     path: ''

--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -52,7 +52,7 @@ layout: default
     <div class="container">
 
       <div class="community-programs">
-        <a class="module link-through light" href="/working-groups" id="working-groups">
+        <a class="module link-through light" href="/community/working-groups" id="working-groups">
           <div class="module-details">
             <h3>Working Groups</h3>
             <div class="module-text">{{ page['Working Groups Description'] | markdownify }}</div>

--- a/community.markdown
+++ b/community.markdown
@@ -1,7 +1,7 @@
 ---
 title: Community & Organization
 date: 2018-02-06 15:20:00 Z
-permalink: "/community"
+permalink: "/community/"
 position: 5
 People:
   Description: HOT is a community of community leaders, volunteers, and professionals

--- a/support-programs.markdown
+++ b/support-programs.markdown
@@ -3,6 +3,11 @@ title: Support Programs
 date: 2018-03-09 09:19:00 Z
 layout: page
 permalink: /community/support-programs/
+Intro Text: A short intro to the program
+Page Contact:
+  Label: draft
+  Text: draft text
+  Contact Email: rebecca@hotosm.org
 ---
 
 Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Sed posuere consectetur est at lobortis. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Nullam id dolor id nibh ultricies vehicula ut id elit.

--- a/support-programs.markdown
+++ b/support-programs.markdown
@@ -2,6 +2,7 @@
 title: Support Programs
 date: 2018-03-09 09:19:00 Z
 layout: page
+permalink: /community/support-programs/
 ---
 
 Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Sed posuere consectetur est at lobortis. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Nullam id dolor id nibh ultricies vehicula ut id elit.

--- a/working-groups/index.markdown
+++ b/working-groups/index.markdown
@@ -2,6 +2,9 @@
 title: Working Groups
 position: 0
 layout: groups
+permalink: /community/working-groups/
+redirect_from:
+  - /working-groups
 ---
 
 Description of working groups, how they are used by HOT and along


### PR DESCRIPTION
Small update to correctly link to Support Programs page. Changes url structure to be subpages under community. 