### PR TITLE
add global placeholder for non-country based projects

### DIFF
--- a/_includes/blocks/project-highlight.html
+++ b/_includes/blocks/project-highlight.html
@@ -20,6 +20,10 @@
             <span class="project-country">{{ country }}</span>
           {% endfor %}
         </p>
+      {% else %}
+        <p class="project-countries">
+          <span class="project-country">Global</span>
+        </p>
       {% endif %}
 
     </div>

--- a/_includes/blocks/project-thumb.html
+++ b/_includes/blocks/project-thumb.html
@@ -20,6 +20,10 @@
             <span class="project-country">{{ country }}</span>
           {% endfor %}
         </p>
+      {% else %}
+        <p class="project-countries">
+          <span class="project-country">Global</span>
+        </p>
       {% endif %}
 
     </div>

--- a/_layouts/project-item.html
+++ b/_layouts/project-item.html
@@ -9,7 +9,7 @@ layout: default
     <div class="project-header-meta">
 
       <p class="project-involvement">
-        {% if project['Is Community-Led'] %}
+        {% if page['Is Community-Led'] %}
           Community-Led
         {% else %}
           HOT Program
@@ -27,6 +27,10 @@ layout: default
             {% endfor %}
           {% endfor %}
 
+        </p>
+        {% else %}
+        <p class="project-countries">
+          <span class="project-country">Global</span>
         </p>
       {% endif %}
 


### PR DESCRIPTION
Adds global as text when a country is not defined. 
Fixes the HOT Program or Community Led label on project pages. 