### PR TITLE
add logic to adjust country side bar for showing projects, members text

### DIFF
--- a/_includes/blocks/project-thumb.html
+++ b/_includes/blocks/project-thumb.html
@@ -16,9 +16,15 @@
 
       {% if project.Country[0] != '' %}
         <p class="project-countries">
-          {% for country in project.Country %}
-            <span class="project-country">{{ country }}</span>
-          {% endfor %}
+
+          {% if project.Country.size < 3 %}
+            {% for country in project.Country %}
+              <span class="project-country">{{ country }}</span>
+            {% endfor %}
+          {% else %}
+            {% assign countrycount = project.Country.size %}
+            <span class="project-country">{{ project.Country | first }} and {{ countrycount | minus: 1 }} other countries</span>
+          {% endif %}
         </p>
       {% else %}
         <p class="project-countries">

--- a/_layouts/country.html
+++ b/_layouts/country.html
@@ -52,7 +52,7 @@ layout: default
           <p>Read more about each project below or learn more about <a href="/get-invovled">getting invovled</a>.</p>
         </div>
 
-        <h4>Interested in starting a project?</h4>
+        <h4>Travelling to {{ page.title }} or want to get in touch about a collaboration?</h4>
         <div class="country-content">
           <p>Get in touch with HOT or reach out to the <a href="https://wiki.openstreetmap.org/wiki/Mailing_lists#Country-Specific_Lists">local community</a>.</p>
         </div>
@@ -82,7 +82,7 @@ layout: default
           <p>Read more about <a href="/get-invovled">getting invovled</a> with HOT.</p>
         </div>
 
-        <h4>Interested in starting a project?</h4>
+        <h4>Travelling to {{ page.title }} or want to get in touch about a collaboration?</h4>
         <div class="country-content">
           <p>Get in touch with HOT or reach out to the <a href="https://wiki.openstreetmap.org/wiki/Mailing_lists#Country-Specific_Lists">local community</a>.</p>
         </div>
@@ -106,7 +106,7 @@ layout: default
         {% else %}
 
         <!-- Countries without projects or members -->
-        <h4>Interested in starting a project?</h4>
+        <h4>Have a project or collaboration idea for {{ page.title }}?</h4>
         <div class="country-content">
           <p>Get in touch with HOT or reach out to the <a href="https://wiki.openstreetmap.org/wiki/Mailing_lists#Country-Specific_Lists">local community</a>.</p>
         </div>

--- a/_layouts/country.html
+++ b/_layouts/country.html
@@ -1,6 +1,25 @@
 ---
 layout: default
 ---
+{% assign sorted-projects = site.projects | sort:"position" %}
+{% assign projects = false %}
+{% assign members = false %}
+{% assign projectcount = 0 %}
+{% assign memberscount = 0 %}
+
+{% for project in sorted-projects %}
+  {% if project['Country'] contains page.title %}
+    {% assign projects = true %}
+    {% assign projectcount = projectcount | plus: 1 %}
+  {% endif %}
+{% endfor %}
+
+{% for person in site.people %}
+  {% if page.title contains person.Country %}
+    {% assign members = true %}
+    {% assign memberscount = memberscount | plus: 1 %}
+  {% endif %}
+{% endfor %}
 
 <div class="project-index country-index">
 
@@ -23,11 +42,21 @@ layout: default
 
     <div class="country-contact">
       <div class="country-contact-wrapper">
-        <h4>Want to start a project in {{ page.title }}?</h4>
-        <div class="country-content">
-          {{ content }}
+
+        {% if projects %}
+
+        <!-- Countries with projects -->
+
+        <h4>{{ page.title }} has {{ projectcount }} project{% if projectcount > 1%}s{%endif%}{% if memberscount > 0%} and {{ memberscount }} voting member{% if memberscount > 1%}s{%endif%}{%endif%}</h4>
+        <div class="country-content top">
+          <p>Read more about each project below or learn more about <a href="/get-invovled">getting invovled</a>.</p>
         </div>
-        <h5>Contact</h5>
+
+        <h4>Interested in starting a project?</h4>
+        <div class="country-content">
+          <p>Get in touch with HOT or reach out to the <a href="https://wiki.openstreetmap.org/wiki/Mailing_lists#Country-Specific_Lists">local community</a>.</p>
+        </div>
+        <h5>Contact HOT</h5>
         {% if page['Contact Person'].Name or page['Contact Person'].Title or page['Contact Person'].Email or page['Contact Person'].Phone %}
           <p><b>{{ page['Contact Person'].Name }}</b></p>
           <p>{{ page['Contact Person'].Title }}</p>
@@ -42,6 +71,62 @@ layout: default
           <p><b>{{ page.Location['Location Name'] }}</b></p>
           {{ page.Location.Address | markdownify }}
           <p>{{ page.Location.Phone }}</p>
+        {% endif %}
+        
+        {% elsif members %}
+
+        <!-- Countries with members only -->
+
+        <h4>{{ page.title }} has {{ memberscount }} voting member{% if memberscount > 1%}s{%endif%}</h4>
+        <div class="country-content top">
+          <p>Read more about <a href="/get-invovled">getting invovled</a> with HOT.</p>
+        </div>
+
+        <h4>Interested in starting a project?</h4>
+        <div class="country-content">
+          <p>Get in touch with HOT or reach out to the <a href="https://wiki.openstreetmap.org/wiki/Mailing_lists#Country-Specific_Lists">local community</a>.</p>
+        </div>
+        <h5>Contact HOT</h5>
+        {% if page['Contact Person'].Name or page['Contact Person'].Title or page['Contact Person'].Email or page['Contact Person'].Phone %}
+          <p><b>{{ page['Contact Person'].Name }}</b></p>
+          <p>{{ page['Contact Person'].Title }}</p>
+          <p><a href="mailto:{{ page['Contact Person'].Email }}">{{ page['Contact Person'].Email }}</a></p>
+          <p>{{ page['Contact Person'].Phone }}</p>
+        {% else %}
+          <a href="mailto:info@hotosm.org">info@hotosm.org</a>
+        {% endif %}
+
+        {% if page.Location.Name or page.Location.Address %}
+          <h5>Visit</h5>
+          <p><b>{{ page.Location['Location Name'] }}</b></p>
+          {{ page.Location.Address | markdownify }}
+          <p>{{ page.Location.Phone }}</p>
+        {% endif %}
+        
+        {% else %}
+
+        <!-- Countries without projects or members -->
+        <h4>Interested in starting a project?</h4>
+        <div class="country-content">
+          <p>Get in touch with HOT or reach out to the <a href="https://wiki.openstreetmap.org/wiki/Mailing_lists#Country-Specific_Lists">local community</a>.</p>
+        </div>
+        <h5>Contact HOT</h5>
+        {% if page['Contact Person'].Name or page['Contact Person'].Title or page['Contact Person'].Email or page['Contact Person'].Phone %}
+          <p><b>{{ page['Contact Person'].Name }}</b></p>
+          <p>{{ page['Contact Person'].Title }}</p>
+          <p><a href="mailto:{{ page['Contact Person'].Email }}">{{ page['Contact Person'].Email }}</a></p>
+          <p>{{ page['Contact Person'].Phone }}</p>
+        {% else %}
+          <a href="mailto:info@hotosm.org">info@hotosm.org</a>
+        {% endif %}
+
+        {% if page.Location.Name or page.Location.Address %}
+          <h5>Visit</h5>
+          <p><b>{{ page.Location['Location Name'] }}</b></p>
+          {{ page.Location.Address | markdownify }}
+          <p>{{ page.Location.Phone }}</p>
+        {% endif %}
+
         {% endif %}
       </div>
     </div>
@@ -78,8 +163,6 @@ layout: default
       <p class="stat-title">Roads Mapped (KM)</p>
     </div>
   </div>
-
-  {% assign sorted-projects = site.projects | sort:"position" %}
 
   {% for project in sorted-projects %}
     {% if project['Country'] contains page.title %}

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -2452,7 +2452,7 @@ em {
   }
   .country-content {
     p {
-
+      margin-bottom: 24px;
     }
   }
 }


### PR DESCRIPTION
Initial structure and take for how we can adjust the sidebar text for country pages. This will be dependent on if the country has projects and/or members. This is more of a temporary layout until we revamp the project and country pages based on our discussion in https://github.com/hotosm/hotosm-website/issues/128#issuecomment-370768624

### Questions :question: 

Do we want to improve the language more?
I've added some connection to local community links but ideally we pull in https://github.com/osmlab/osm-community-index in the future

## Country with projects, members, and an office
![fireshot capture 14 - humanitarian openstreetmap team_ - http___localhost_4000_where-we-work_uganda_](https://user-images.githubusercontent.com/796838/39867349-6e344358-544c-11e8-99f2-2b511695c2fb.png)

## Country with members only 
![fireshot capture 17 - humanitarian openstreetmap te_ - http___localhost_4000_where-we-work_portugal_](https://user-images.githubusercontent.com/796838/39867347-6df55bc0-544c-11e8-955f-0cf05ec9886a.png)

## Country with out projects or members
![fireshot capture 15 - humanitarian openstreetmap team_ - http___localhost_4000_where-we-work_belize_](https://user-images.githubusercontent.com/796838/39867348-6e14264a-544c-11e8-83d3-74a30f71df27.png)

