### PR TITLE
Information on stats bar

### DIFF
--- a/_layouts/country.html
+++ b/_layouts/country.html
@@ -144,7 +144,7 @@ layout: default
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Community-Mappers"></p>
       <p class="stat-title">Community Mappers<sup>&#9432;</sup>
-        <span class="tooltiptext">Total number of Mappers</span>
+        <span class="tooltiptext">Total number of Mappers from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> project</span>
       </p>
     </div>
     <div class="hr-v"></div>
@@ -152,7 +152,7 @@ layout: default
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Total-Map-Edits"></p>
       <p class="stat-title">Total Map Edits<sup>&#9432;</sup>
-        <span class="tooltiptext">Total number of Edits</span>
+        <span class="tooltiptext">Total number of Edits from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> project</span>
       </p>
     </div>
     <div class="hr-v hide-sm"></div>
@@ -160,7 +160,7 @@ layout: default
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Buildings-Mapped"></p>
       <p class="stat-title">Buildings Mapped<sup>&#9432;</sup>
-        <span class="tooltiptext">Total number of Buildings mapped</span>
+        <span class="tooltiptext">Total number of Buildings mapped from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> project</span>
       </p>
     </div>
     <div class="hr-v"></div>
@@ -168,7 +168,7 @@ layout: default
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Roads-Mapped"></p>
       <p class="stat-title">Roads Mapped (KM)<sup>&#9432;</sup>
-        <span class="tooltiptext">Total length of Roads mapped</span>
+        <span class="tooltiptext">Total length of Roads mapped from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> project</span>
       </p>
     </div>
   </div>

--- a/_layouts/country.html
+++ b/_layouts/country.html
@@ -143,7 +143,7 @@ layout: default
     <div class="home-stat">
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Community-Mappers"></p>
-      <p class="stat-title">Community Mappers
+      <p class="stat-title">Community Mappers<sup>&#9432;</sup>
         <span class="tooltiptext">Total number of Mappers</span>
       </p>
     </div>
@@ -151,7 +151,7 @@ layout: default
     <div class="home-stat">
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Total-Map-Edits"></p>
-      <p class="stat-title">Total Map Edits
+      <p class="stat-title">Total Map Edits<sup>&#9432;</sup>
         <span class="tooltiptext">Total number of Edits</span>
       </p>
     </div>
@@ -159,7 +159,7 @@ layout: default
     <div class="home-stat">
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Buildings-Mapped"></p>
-      <p class="stat-title">Buildings Mapped
+      <p class="stat-title">Buildings Mapped<sup>&#9432;</sup>
         <span class="tooltiptext">Total number of Buildings mapped</span>
       </p>
     </div>
@@ -167,7 +167,7 @@ layout: default
     <div class="home-stat">
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Roads-Mapped"></p>
-      <p class="stat-title">Roads Mapped (KM)
+      <p class="stat-title">Roads Mapped (KM)<sup>&#9432;</sup>
         <span class="tooltiptext">Total length of Roads mapped</span>
       </p>
     </div>

--- a/_layouts/country.html
+++ b/_layouts/country.html
@@ -143,25 +143,33 @@ layout: default
     <div class="home-stat">
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Community-Mappers"></p>
-      <p class="stat-title">Community Mappers</p>
+      <p class="stat-title">Community Mappers
+        <span class="tooltiptext">Total number of Mappers</span>
+      </p>
     </div>
     <div class="hr-v"></div>
     <div class="home-stat">
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Total-Map-Edits"></p>
-      <p class="stat-title">Total Map Edits</p>
+      <p class="stat-title">Total Map Edits
+        <span class="tooltiptext">Total number of Edits</span>
+      </p>
     </div>
     <div class="hr-v hide-sm"></div>
     <div class="home-stat">
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Buildings-Mapped"></p>
-      <p class="stat-title">Buildings Mapped</p>
+      <p class="stat-title">Buildings Mapped
+        <span class="tooltiptext">Total number of Buildings mapped</span>
+      </p>
     </div>
     <div class="hr-v"></div>
     <div class="home-stat">
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Roads-Mapped"></p>
-      <p class="stat-title">Roads Mapped (KM)</p>
+      <p class="stat-title">Roads Mapped (KM)
+        <span class="tooltiptext">Total length of Roads mapped</span>
+      </p>
     </div>
   </div>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -58,7 +58,7 @@ layout: default
       <center><p id ="mappers" class="loader"></p></center>
       <p class="stat-number" id="Community-Mappers"></p>
       <p class="stat-title">Community Mappers<sup>&#9432;</sup>
-        <span class="tooltiptext">Total number of Mappers</span>
+        <span class="tooltiptext">Total number of Mappers from HOT Community</span>
       </p>
     </div>
     <div class="hr-v"></div>
@@ -66,7 +66,7 @@ layout: default
       <center><p id ="edits" class="loader"></p></center>
       <p class="stat-number" id="Total-Map-Edits"></p>
       <p class="stat-title">Total Map Edits<sup>&#9432;</sup>
-        <span class="tooltiptext">Total number of Edits</span>
+        <span class="tooltiptext">Total number of Edits from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> project</span>
       </p>
     </div>
     <div class="hr-v hide-sm"></div>
@@ -74,7 +74,7 @@ layout: default
       <center><p id ="buildings" class="loader"></p></center>
       <p class="stat-number" id="Buildings-Mapped"></p>
       <p class="stat-title">Buildings Mapped<sup>&#9432;</sup>
-        <span class="tooltiptext">Total number of Buildings mapped</span>
+        <span class="tooltiptext">Total number of Buildings mapped from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> project</span>
       </p>
     </div>
     <div class="hr-v"></div>
@@ -82,7 +82,7 @@ layout: default
       <center><p id ="roads" class="loader"></p></center>
       <p class="stat-number" id="Roads-Mapped"></p>
       <p class="stat-title">Roads Mapped (KM)<sup>&#9432;</sup>
-        <span class="tooltiptext">Total length of Roads mapped</span>
+        <span class="tooltiptext">Total length of Roads mapped from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> project</span>
       </p>
     </div>
   </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -57,7 +57,7 @@ layout: default
     <div class="home-stat">
       <center><p id ="mappers" class="loader"></p></center>
       <p class="stat-number" id="Community-Mappers"></p>
-      <p class="stat-title">Community Mappers
+      <p class="stat-title">Community Mappers<sup>&#9432;</sup>
         <span class="tooltiptext">Total number of Mappers</span>
       </p>
     </div>
@@ -65,7 +65,7 @@ layout: default
     <div class="home-stat">
       <center><p id ="edits" class="loader"></p></center>
       <p class="stat-number" id="Total-Map-Edits"></p>
-      <p class="stat-title">Total Map Edits
+      <p class="stat-title">Total Map Edits<sup>&#9432;</sup>
         <span class="tooltiptext">Total number of Edits</span>
       </p>
     </div>
@@ -73,7 +73,7 @@ layout: default
     <div class="home-stat">
       <center><p id ="buildings" class="loader"></p></center>
       <p class="stat-number" id="Buildings-Mapped"></p>
-      <p class="stat-title">Buildings Mapped
+      <p class="stat-title">Buildings Mapped<sup>&#9432;</sup>
         <span class="tooltiptext">Total number of Buildings mapped</span>
       </p>
     </div>
@@ -81,7 +81,7 @@ layout: default
     <div class="home-stat">
       <center><p id ="roads" class="loader"></p></center>
       <p class="stat-number" id="Roads-Mapped"></p>
-      <p class="stat-title">Roads Mapped (KM)
+      <p class="stat-title">Roads Mapped (KM)<sup>&#9432;</sup>
         <span class="tooltiptext">Total length of Roads mapped</span>
       </p>
     </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -57,25 +57,33 @@ layout: default
     <div class="home-stat">
       <center><p id ="mappers" class="loader"></p></center>
       <p class="stat-number" id="Community-Mappers"></p>
-      <p class="stat-title">Community Mappers</p>
+      <p class="stat-title">Community Mappers
+        <span class="tooltiptext">Total number of Mappers</span>
+      </p>
     </div>
     <div class="hr-v"></div>
     <div class="home-stat">
       <center><p id ="edits" class="loader"></p></center>
       <p class="stat-number" id="Total-Map-Edits"></p>
-      <p class="stat-title">Total Map Edits</p>
+      <p class="stat-title">Total Map Edits
+        <span class="tooltiptext">Total number of Edits</span>
+      </p>
     </div>
     <div class="hr-v hide-sm"></div>
     <div class="home-stat">
       <center><p id ="buildings" class="loader"></p></center>
       <p class="stat-number" id="Buildings-Mapped"></p>
-      <p class="stat-title">Buildings Mapped</p>
+      <p class="stat-title">Buildings Mapped
+        <span class="tooltiptext">Total number of Buildings mapped</span>
+      </p>
     </div>
     <div class="hr-v"></div>
     <div class="home-stat">
       <center><p id ="roads" class="loader"></p></center>
       <p class="stat-number" id="Roads-Mapped"></p>
-      <p class="stat-title">Roads Mapped (KM)</p>
+      <p class="stat-title">Roads Mapped (KM)
+        <span class="tooltiptext">Total length of Roads mapped</span>
+      </p>
     </div>
   </div>
 

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -2951,6 +2951,39 @@ em {
   @media (max-width: $screen-xs) {
     font-size: 0.8125rem;
   }
+  position: relative;
+}
+
+.tooltiptext {
+  visibility: hidden;
+  width: 160px;
+  top: 22px;
+  left: 50px;
+  background-color: rgba(107, 97, 97, 0.5);
+  color: #fff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+  position: absolute;
+  z-index: 1;
+  opacity: 0;
+  transition: opacity 1s;
+}
+
+.stat-title:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1; 
+}
+
+.stat-title .tooltiptext::after {
+  content: " ";
+  position: absolute;
+  bottom: 100%; 
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent rgba(107, 97, 97, 0.5) transparent;
 }
 
 

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -2953,7 +2953,10 @@ em {
   }
   position: relative;
 }
-
+sup {
+  vertical-align: super;
+  font-size: xx-small;
+}
 .tooltiptext {
   visibility: hidden;
   width: 160px;


### PR DESCRIPTION
From country page:

![tooltip](https://user-images.githubusercontent.com/12103383/40005677-377feae8-57b6-11e8-8c7c-18beebe16548.gif)


In both the cases using a tooltip that appears on hovering over stats-title. Using an [unicode character](https://www.charbase.com/24d8-unicode-circled-latin-small-letter-i) to represent an info-icon. However tooltip appears on hover over stats-title and not just the info icon.

@smit1678 - Tooltip covers both the stats description and the source from where it is pulled? 
