### PR TITLE
adjust working group layout to add links, remove subpages for now

### DIFF
--- a/_layouts/groups.html
+++ b/_layouts/groups.html
@@ -20,12 +20,20 @@ layout: default
 
         {% if page.url contains "/working-groups/" %}
           {% for group in site.working-groups %}
-            <a href="{{ group.url }}" class="module light link-through">
+            <div class="module light link-through">
               <div class="module-details">
                 <h3>{{ group.title }}</h3>
-                <div class="module-text"><p>{{ group.content }}</p></div>
+                <div class="module-text">
+                  {{ group.content }}
+                  <p>
+                    <a href="{{ group['TOR'] }}">Purpose and details</a> | 
+                    <a href="{{ group['Project Tracking'] }}">Project Tracking</a> | 
+                    <a href="{{ group['Calendar'] }}">Calendar link</a> | 
+                    <a href="{{ group['Slack Channel'] }}">Chat Space</a>
+                  </p>
+                </div>
               </div>
-            </a>
+            </div>
           {% endfor %}
         {% endif %}
 

--- a/_layouts/groups.html
+++ b/_layouts/groups.html
@@ -26,10 +26,18 @@ layout: default
                 <div class="module-text">
                   {{ group.content }}
                   <p>
-                    <a href="{{ group['TOR'] }}">Purpose and details</a> | 
-                    <a href="{{ group['Project Tracking'] }}">Project Tracking</a> | 
-                    <a href="{{ group['Calendar'] }}">Calendar link</a> | 
-                    <a href="{{ group['Slack Channel'] }}">Chat Space</a>
+                    {% if group['Details'] %}
+                    <a href="{{ group['Details'] }}">Details</a> | 
+                    {% endif %}
+                    {% if group['Coordination'] %}
+                    <a href="{{ group['Coordination'] }}">Coordination</a> | 
+                    {% endif %}
+                    {% if group['Calendar'] %}
+                    <a href="{{ group['Calendar'] }}">Calendar</a> | 
+                    {% endif %}
+                    {% if group['Chat'] %}
+                    <a href="{{ group['Chat'] }}">Chat</a>
+                    {% endif %}
                   </p>
                 </div>
               </div>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -3434,7 +3434,7 @@ em {
   .module-text {
     p {
       line-height: 1.4;
-      margin-bottom: 0;
+      margin-bottom: 12px;
     }
   }
 }

--- a/_working-groups/activation.markdown
+++ b/_working-groups/activation.markdown
@@ -1,10 +1,10 @@
 ---
 title: Activation
 date: 2018-02-15 13:21:00 Z
-Project Tracking: 
+Coordination: 
 Calendar: "https://www.google.com/calendar/embed?src=hotosm.org_848e89aaiab04ag94d23rqn558%40group.calendar.google.com"
-Slack Channel: disaster-mapping
-TOR: "https://docs.google.com/document/d/1uf60-HUF9GyP68-DzzksEa8RLqFkUrsNSq6vhiiXa64/edit?usp=sharing"
+Chat: disaster-mapping
+Details: "https://docs.google.com/document/d/1uf60-HUF9GyP68-DzzksEa8RLqFkUrsNSq6vhiiXa64/edit?usp=sharing"
 ---
 
 This group is tasked with developing and/or proposing procedures, monitoring, tools, and/or other recommendations for management of HOT's distaster mapping program.

--- a/_working-groups/activation.markdown
+++ b/_working-groups/activation.markdown
@@ -1,6 +1,10 @@
 ---
 title: Activation
 date: 2018-02-15 13:21:00 Z
+Project Tracking: 
+Calendar: "https://www.google.com/calendar/embed?src=hotosm.org_848e89aaiab04ag94d23rqn558%40group.calendar.google.com"
+Slack Channel: disaster-mapping
+TOR: "https://docs.google.com/document/d/1uf60-HUF9GyP68-DzzksEa8RLqFkUrsNSq6vhiiXa64/edit?usp=sharing"
 ---
 
 This group is tasked with developing and/or proposing procedures, monitoring, tools, and/or other recommendations for management of HOT's distaster mapping program.

--- a/_working-groups/communications.markdown
+++ b/_working-groups/communications.markdown
@@ -1,6 +1,10 @@
 ---
 title: Communications
 date: 2018-02-15 13:21:00 Z
+Coordination: 
+Calendar:
+Chat:
+Details:
 ---
 
 This group develops and manages policies and procedures regarding external communications, press releases, general texts and online publications.

--- a/_working-groups/community.markdown
+++ b/_working-groups/community.markdown
@@ -1,6 +1,10 @@
 ---
 title: Community
 date: 2018-02-15 13:21:00 Z
+Coordination: 
+Calendar:
+Chat:
+Details:
 ---
 
 This group works to improve the global HOT community through targeted actions. An improved community is a one which works together better, and which fosters and supports the growth of local groups around the world.

--- a/_working-groups/fundraising.markdown
+++ b/_working-groups/fundraising.markdown
@@ -1,6 +1,10 @@
 ---
 title: Fundraising
 date: 2018-02-15 13:22:00 Z
+Coordination: 
+Calendar:
+Chat:
+Details:
 ---
 
 In order to remain a reliable force in non-traditional humanitarian response there is a need for sustainable funding for HOT. This working group recommends fundraising strategies and goals to the HOT board.

--- a/_working-groups/governance.markdown
+++ b/_working-groups/governance.markdown
@@ -1,6 +1,10 @@
 ---
 title: Governance
 date: 2018-02-15 13:22:00 Z
+Coordination: 
+Calendar:
+Chat:
+Details:
 ---
 
 This group is charged with governance aspects of HOT, on how the organisation should be structured and work together and defining the legal bases.

--- a/_working-groups/security.markdown
+++ b/_working-groups/security.markdown
@@ -1,6 +1,10 @@
 ---
 title: Security
 date: 2018-02-15 13:22:00 Z
+Coordination: 
+Calendar:
+Chat:
+Details:
 ---
 
 Security working group is a new group which will establish security policies and SOPs and generally look after the safety and security of HOT in the field as well as working remotely.

--- a/_working-groups/technical.markdown
+++ b/_working-groups/technical.markdown
@@ -1,6 +1,10 @@
 ---
 title: Technical
 date: 2018-02-15 13:22:00 Z
+Coordination: 
+Calendar:
+Chat:
+Details:
 ---
 
 The HOT Technical Working Group discusses the current status, coordination possibilities, and priorities for tool development, and for hosting and operations aspects of HOT tools.

--- a/_working-groups/training.markdown
+++ b/_working-groups/training.markdown
@@ -1,6 +1,10 @@
 ---
 title: Training
 date: 2018-02-15 13:22:00 Z
+Coordination: 
+Calendar:
+Chat:
+Details:
 ---
 
 Much of what HOT does involves training others how to contribute to and use OpenStreetMap. The training group organizes and consolidates training materials and helps direct development of them to satisfy the identified audiences.

--- a/working-groups/index.markdown
+++ b/working-groups/index.markdown
@@ -7,8 +7,4 @@ redirect_from:
 - "/working-groups"
 ---
 
-Description of working groups, how they are used by HOT and along
-  with information on how and individual can get involved with a group. Nullam
-  quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus
-  et magnis dis parturient montes, [email@example.com](email@example.com) nascetur
-  ridiculus mus.
+Description of working groups, how they are used by HOT and along with information on how and individual can get involved with a group. Check out the links for how to get involved, join the next meeting, or understand their function more.


### PR DESCRIPTION
Adds additional information to Working Group listing. Instead of linking to subpages, listing the information on the WG index page. 

@russdeffner Should we have any other links on each of the items? 

<img width="960" alt="humanitarian openstreetmap team working groups 2018-05-28 10-44-35" src="https://user-images.githubusercontent.com/796838/40608676-205c6158-6264-11e8-9226-676e830e4141.png">
