### PR TITLE
Stats for landing page

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -3,3 +3,4 @@
 <script src="{{ "/js/main.js" | prepend: site.baseurl }}"></script>
 {% if page.layout == 'home' %}<script src="{{ "/js/stats.js" | prepend: site.baseurl }}"></script>{% endif %}
 {% if page.layout == 'country' %}<script src="{{ "/js/countries-stats.js" | prepend: site.baseurl }}"></script>{% endif %}
+{% if page.layout == 'project-index' %}<script src="{{ "/js/home-stats.js" | prepend: site.baseurl }}"></script>{% endif %}

--- a/_layouts/project-index.html
+++ b/_layouts/project-index.html
@@ -41,6 +41,7 @@ layout: default
           </div>
         </div>
       </div>
+      
     </div>
 
 
@@ -66,8 +67,35 @@ layout: default
 
   </div>
 
-  <div id="our-work-projects" class="container">
-
+    <div id="our-work-projects" class="container">
+      <div class="container home-stats">
+        <div class="home-stat">
+            <center><p id ="mappers" class="loader"></p></center>
+            <p class="stat-number" id="Community-Mappers"></p>
+            <p class="stat-title">Total Mappers<sup>&#9432;</sup>
+              <span class="tooltiptext">Total number of HOT Community Mappers</span>
+            </p>
+        </div>
+        <div class="hr-v"></div>
+        <div class="home-stat">
+          <center><p id ="online-mappers" class="loader"></p></center>
+          <p class="stat-number" id="Online-Mappers"></p>
+          <p class="stat-title">Mappers Online<sup>&#9432;</sup>
+            <span class="tooltiptext">Total number of mappers currently active on HOT</span>
+          </p>
+        </div>
+        <div class="hr-v"></div>
+    
+        <div class="hr-v hide-sm"></div>
+        <div class="home-stat">
+          <center><p id ="task" class="loader"></p></center>
+          <p class="stat-number" id="Tasks-Mapped"></p>
+          <p class="stat-title">Total Tasks<sup>&#9432;</sup>
+            <span class="tooltiptext">Total number of tasks mapped by the Community</span>
+          </p>
+        </div>
+        
+      </div>
     <h6>Highlighted Projects</h6>
 
     <div class="project-index-highlights">
@@ -93,6 +121,7 @@ layout: default
     </div>
 
   </div>
+  
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.js'></script>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.css' rel='stylesheet' />
   <script src="{{ "/js/our-work-map.js" | prepend: site.baseurl }}"></script>

--- a/js/home-stats.js
+++ b/js/home-stats.js
@@ -1,7 +1,6 @@
 $(document).ready(function () {
     $('.loader').show();
     $.get('https://tasks.hotosm.org/api/v1/stats/home-page', function (data) {
-      console.log(data)
       $('#Community-Mappers').text(formatedData(data['totalMappers']));
       $('#Online-Mappers').text(formatedData(data['mappersOnline']));
       $('#Tasks-Mapped').text(formatedData(data['tasksMapped']));

--- a/js/home-stats.js
+++ b/js/home-stats.js
@@ -1,0 +1,10 @@
+$(document).ready(function () {
+    $('.loader').show();
+    $.get('https://tasks.hotosm.org/api/v1/stats/home-page', function (data) {
+      console.log(data)
+      $('#Community-Mappers').text(formatedData(data['totalMappers']));
+      $('#Online-Mappers').text(formatedData(data['mappersOnline']));
+      $('#Tasks-Mapped').text(formatedData(data['tasksMapped']));
+      $('.loader').hide();
+    });
+  });


### PR DESCRIPTION
For now just having a placeholder with [home-stats from TM](https://tasks.hotosm.org/api/v1/stats/home-page). This section will undergo further changes as layout discussed in https://github.com/hotosm/hotosm-website/issues/128 gets implemented.

![image](https://user-images.githubusercontent.com/12103383/40612165-0795744c-6297-11e8-984c-31a0dac68a6a.png)

cc @smit1678 