### PR TITLE
Add top aligned image toggle for projects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,9 +45,9 @@ defaults:
   values:
     permalink: updates/:title/
     layout: news-item
-    Summary Text: 
-    Feature Image: 
-    Person: 
+    Summary Text:
+    Feature Image:
+    Person:
     Working Group:
     - ''
     Country:
@@ -59,23 +59,23 @@ defaults:
     type: people
   values:
     layout: person
-    Photo: 
+    Photo:
     Member Type:
-      Is Staff: 
-      Is Voting Member: 
-      Is Board Member: 
-    Job Title: 
+      Is Staff:
+      Is Voting Member:
+      Is Board Member:
+    Job Title:
     Working Group:
     - ''
     Project:
     - ''
-    Country: 
+    Country:
     Social Media (Full URL):
-      OSM: 
-      Twitter: 
-      LinkedIn: 
-      Facebook: 
-      Instagram: 
+      OSM:
+      Twitter:
+      LinkedIn:
+      Facebook:
+      Instagram:
 - scope:
     path: ''
     type: impact-areas
@@ -87,38 +87,39 @@ defaults:
     type: tools
   values:
     layout: impact-area
-    Tool URL: 
+    Tool URL:
 - scope:
     path: ''
     type: jobs
   values:
     layout: page
-    Deadline Date: 
-    Place of Work: 
-    Apply Form Link: 
+    Deadline Date:
+    Place of Work:
+    Apply Form Link:
 - scope:
     path: ''
     type: where-we-work
   values:
     layout: country
     Contact Person:
-      Name: 
-      Title: 
-      Email: 
-      Phone: 
+      Name:
+      Title:
+      Email:
+      Phone:
     Location:
-      Location Name: 
-      Address: 
-      Phone: 
-      Map Link: 
+      Location Name:
+      Address:
+      Phone:
+      Map Link:
 - scope:
     path: ''
     type: projects
   values:
     layout: project-item
-    Project Summary Text: 
-    Feature Image: 
-    Is Community-Led: 
+    Project Summary Text:
+    Feature Image:
+    Is image top aligned:
+    Is Community-Led:
     Country:
     - ''
     Impact Area:
@@ -128,14 +129,14 @@ defaults:
     Partner:
     - ''
     Duration:
-      Start Date: 
+      Start Date:
       End Date: Ongoing
 email: info@hotosm.org
 description: Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for Google search
   results) and in your feed.xml site description.
-baseurl: 
-url: 
+baseurl:
+url:
 twitter_username: hotosm
 github_username: hotosm
 markdown: kramdown

--- a/_includes/blocks/project-highlight.html
+++ b/_includes/blocks/project-highlight.html
@@ -13,7 +13,7 @@
           HOT Program
         {% endif %}
       </p>
-      
+
       {% if project.Country[0] != '' %}
         <p class="project-countries">
           {% for country in project.Country %}
@@ -32,7 +32,7 @@
   </div>
   <div class="module-image">
     {% if project['Feature Image'] %}
-      <img src="{{ project['Feature Image']}}">
+      <img {% if project['Is image top aligned'] %} style="object-position: top center" {% endif %} src="{{ project['Feature Image']}}">
     {% endif %}
   </div>
 

--- a/_includes/blocks/project-thumb.html
+++ b/_includes/blocks/project-thumb.html
@@ -38,7 +38,7 @@
 
   <div class="module-image">
     {% if project['Feature Image'] %}
-      <img src="{{ project['Feature Image']}}">
+      <img {% if project['Is image top aligned'] %} style="object-position: top center" {% endif %} src="{{ project['Feature Image']}}">
     {% endif %}
   </div>
 

--- a/_layouts/project-item.html
+++ b/_layouts/project-item.html
@@ -40,7 +40,7 @@ layout: default
   <div class="project-body">
 
     {% if page['Feature Image'] %}
-      <img class="project-feature-image" src="{{ page['Feature Image' ]}}">
+      <img class="project-feature-image" {% if page['Is image top aligned'] %} style="object-position: top center" {% endif %} src="{{ page['Feature Image' ]}}">
     {% endif %}
 
     <section class="article">

--- a/_projects/openstreetmap-guinea.markdown
+++ b/_projects/openstreetmap-guinea.markdown
@@ -5,6 +5,7 @@ position: 6
 Project Summary Text: Using OpenStreetMap to improve the private health sector in
   Conakry
 Feature Image: "/uploads/Training%20December%2023,%20OSM%20Guinea,%20Nethope%202017.jpg"
+Is image top aligned: true
 Is Community-Led: true
 Country:
 - Guinea


### PR DESCRIPTION
Add toggle `Is image top aligned` to projects for cases when image crops are cutting heads off at the top. This also changes the crop for project thumbnail images.

Toggle set to `false` (default center alignment)
<img width="1444" alt="screenshot 2018-06-06 12 17 22" src="https://user-images.githubusercontent.com/1270986/41036282-75024afe-6987-11e8-9a68-48404c911416.png">

Toggle set to `true`
<img width="1444" alt="screenshot 2018-06-06 12 20 46" src="https://user-images.githubusercontent.com/1270986/41036283-7522b06e-6987-11e8-8cd7-dd3345a66837.png">
