### PR TITLE
add logic for when sections are empty

### DIFF
--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -37,15 +37,21 @@ layout: default
         <div class="person-bio">
           <h6>Bio</h6>
           <div class="person-content">
+            {% assign content = post.content | strip_newlines %}
             {{ content }}
+            {% if content == "" %}
+              <p>{{ page.title }} is a voting member of HOT.</p>
+            {% endif %}
           </div>
         </div>
 
         <div class="person-posts">
           <h6>Posts</h6>
           <div class="person-posts-list">
+            {% assign checkposts = false %}
             {% for post in site.posts %}
               {% if post.Person contains page.title %}
+              {% assign checkposts = true %}
               <div class="news-index-item">
                 <div class="news-list-summary">
                   <div class="news-list-summary-text {% if post['Feature Image'] %}with-image{% endif %}">
@@ -73,19 +79,29 @@ layout: default
               </div>
               {% endif %}
             {% endfor %}
+
+            {% if checkposts == false %}
+              <p>No blog posts yet. <a href="/updates">View all news.</a></p>
+            {% endif %}
           </div>
         </div>
 
         <div class="person-projects">
           <h6>Project Contributions</h6>
             <div class="person-projects-list">
+              {% assign checkprojects = false %}
               {% for person-project in page.Project %}
                 {% for project in site.projects %}
                   {% if person-project == project.title %}
                     {% include blocks/project-thumb.html %}
+                    {% assign checkprojects = true %}
                   {% endif %}
                 {% endfor %}
               {% endfor %}
+
+              {% if checkprojects == false %}
+                <p>Not listed as coordinator on any projects. <a href="/our-work">View all projects.</a></p>
+              {% endif %}
           </div>
         </div>
 

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -45,7 +45,7 @@ layout: default
           </div>
         </div>
 
-        <div class="person-posts">
+        <div class="person-posts {% for post in site.posts %}{% if post.Person contains page.title %}present{% break %}{% endif %}{% endfor %}">
           <h6>Posts</h6>
           <div class="person-posts-list">
             {% assign checkposts = false %}
@@ -79,33 +79,29 @@ layout: default
               </div>
               {% endif %}
             {% endfor %}
-
-            {% if checkposts == false %}
-              <p>No blog posts yet. <a href="/updates">View all news.</a></p>
-            {% endif %}
           </div>
+          {% if checkposts == false %}
+            <p class="empty">No blog posts yet. <a href="/updates">View all news.</a></p>
+          {% endif %}
         </div>
 
         <div class="person-projects">
           <h6>Project Contributions</h6>
-            <div class="person-projects-list">
-              {% assign checkprojects = false %}
-              {% for person-project in page.Project %}
-                {% for project in site.projects %}
-                  {% if person-project == project.title %}
-                    {% include blocks/project-thumb.html %}
-                    {% assign checkprojects = true %}
-                  {% endif %}
-                {% endfor %}
+          <div class="person-projects-list">
+            {% assign checkprojects = false %}
+            {% for person-project in page.Project %}
+              {% for project in site.projects %}
+                {% if person-project == project.title %}
+                  {% include blocks/project-thumb.html %}
+                  {% assign checkprojects = true %}
+                {% endif %}
               {% endfor %}
-
-              {% if checkprojects == false %}
-                <p>Not listed as coordinator on any projects. <a href="/our-work">View all projects.</a></p>
-              {% endif %}
+            {% endfor %}
           </div>
+          {% if checkprojects == false %}
+            <p class="empty">Not listed as coordinator on any projects. <a href="/our-work">View all projects.</a></p>
+          {% endif %}
         </div>
-
-
 
       </div>
       <div class="person-sidebar meta">
@@ -133,7 +129,7 @@ layout: default
           </div>
         {% endif %}
 
-        {% if page['Social Media (Full URL)'].OSM != '' and page['Social Media (Full URL)'].Facebook != '' and page['Social Media (Full URL)'].Twitter != '' and page['Social Media (Full URL)'].LinkedIn != '' and page['Social Media (Full URL)'].Instagram != '' %}
+        {% if page['Social Media (Full URL)'].OSM or page['Social Media (Full URL)'].Twitter or page['Social Media (Full URL)'].LinkedIn or page['Social Media (Full URL)'].Facebook or page['Social Media (Full URL)'].Instagram %}
           <div class="meta-item">
             <h5>On The Web</h5>
             <ul>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -3567,6 +3567,10 @@ sup {
       font-size: 1.25rem;
     }
   }
+  .empty {
+    color: $blue-light;
+    margin-bottom: 32px;
+  }
 }
 
 .person-bio {
@@ -3600,12 +3604,17 @@ sup {
   padding-top: 40px;
   border-top: 1px solid $border-color;
   margin-bottom: 16px;
-  display: grid;
-  grid-template-columns: repeat(9, 1fr);
-  grid-gap: 0 24px;
+  &.present {
+    display: grid;
+    grid-template-columns: repeat(9, 1fr);
+    grid-gap: 0 24px;
+  }
   h6 {
-    margin-bottom: 36px;
+    margin-bottom: 18px;
     grid-column: 1 / 3;
+    @media (max-width: $screen-xs) {
+      margin-bottom: 36px;
+    }
   }
   .person-posts-list {
     grid-column: 3 / -1;
@@ -3624,7 +3633,11 @@ sup {
   padding-top: 40px;
   border-top: 1px solid $border-color;
   h6 {
-    margin-bottom: 36px;
+    margin-bottom: 18px;
+    grid-column: 1 / 3;
+    @media (max-width: $screen-xs) {
+      margin-bottom: 36px;
+    }
   }
 }
 


### PR DESCRIPTION
@brendangatens Thoughts on how we can add some logic and text when content isn't filled in yet? Project contributions section doesn't seem to want to play nicely. 

<img width="1360" alt="humanitarian openstreetmap team aaron cope 2018-06-10 23-48-46" src="https://user-images.githubusercontent.com/796838/41206186-15c0b06e-6d09-11e8-9044-3c8a60f80064.png">
