### PR TITLE
add sitemap, update 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,21 +2,7 @@
 layout: default
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
-
-<div class="community">
+<div class="community four-oh-four">
 
   <div class="community-body">
 

--- a/404.html
+++ b/404.html
@@ -16,9 +16,25 @@ layout: default
   }
 </style>
 
-<div class="container">
-  <h1>404</h1>
+<div class="community">
 
-  <p><strong>Page not found :(</strong></p>
-  <p>The requested page could not be found.</p>
+  <div class="community-body">
+
+  <div class="event-promo" id="events">
+    <div class="event-title">
+      <h2>404: Page not found</h2>
+      <img src="/uploads/hot-summit-group-wave.jpg">
+    </div>
+    <div class="event-info">
+      <div class="event-description">
+        <p>Oh no. The page you clicked was not found :(</p>
+        <p>Think this page should be here? Contact <a href="mailto:sysadmin@hotosm.org">sysadmin@hotosm.org</a>.</p>
+        <p>While we have you, if you're interested in mapping, click the link below to start contributing!</p>
+      </div>
+      <a href="https://tasks.hotosm.org/" class="btn btn-primary btn-block btn-chevron">Start mapping now!</a>
+    </div>
+  </div>
+
+  </div>
+
 </div>

--- a/Gemfile
+++ b/Gemfile
@@ -27,3 +27,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'jekyll-paginate'
 gem 'jekyll-redirect-from'
+gem 'jekyll-sitemap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
+    jekyll-sitemap (1.2.0)
+      jekyll (~> 3.3)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
     kramdown (1.16.2)
@@ -56,6 +58,7 @@ DEPENDENCIES
   jekyll-feed (~> 0.6)
   jekyll-paginate
   jekyll-redirect-from
+  jekyll-sitemap
   minima (~> 2.0)
   tzinfo-data
 

--- a/_config.yml
+++ b/_config.yml
@@ -144,5 +144,6 @@ plugins:
 - jekyll-feed
 - jekyll-paginate
 - jekyll-redirect-from
+- jekyll-sitemap
 paginate: 16
 paginate_path: "/updates/page:num/"

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -2983,13 +2983,13 @@ sup {
 
 .stat-title:hover .tooltiptext {
   visibility: visible;
-  opacity: 1; 
+  opacity: 1;
 }
 
 .stat-title .tooltiptext::after {
   content: " ";
   position: absolute;
-  bottom: 100%; 
+  bottom: 100%;
   left: 50%;
   margin-left: -5px;
   border-width: 5px;
@@ -3082,6 +3082,10 @@ sup {
       margin-bottom: 14px;
     }
   }
+}
+
+.four-oh-four .event-promo {
+  margin-bottom: 0;
 }
 
 .finances {


### PR DESCRIPTION
Updates the 404 page to add more information, adds email and links to get mapping. Also adds a sitemap file for use. 

<img width="1386" alt="humanitarian openstreetmap team 2018-06-11 10-11-34" src="https://user-images.githubusercontent.com/796838/41217350-39fd99a4-6d60-11e8-96be-be823692f324.png">
