### PR TITLE
Get rid of extra space on project content

### DIFF
--- a/_layouts/project-item.html
+++ b/_layouts/project-item.html
@@ -46,13 +46,17 @@ layout: default
     <section class="article">
 
       {% if page['Project Summary Text'] %}
-        <div class="project-summary">
-          <p>{{ page['Project Summary Text'] }}</p>
+        <div class="pro-summary-wrap">
+          <div class="project-summary">
+            <p>{{ page['Project Summary Text'] }}</p>
+          </div>
         </div>
       {% endif %}
 
-      <div class="project-content">
-        {{ content }}
+      <div class="pro-content-wrap">
+        <div class="project-content">
+          {{ content }}
+        </div>
       </div>
 
     </section>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -2380,15 +2380,21 @@ em {
     margin: 24px 0 40px;
     padding-top: 24px;
     @media (min-width: $screen-sm) {
+      padding-top: 40px;
       grid-column: 1 / 10;
+    }
+  }
+  .pro-summary-wrap, .pro-content-wrap {
+    @media (min-width: $screen-sm) {
+      grid-column: 1 / -1;
       display: grid;
       grid-gap: 0 24px;
       grid-template-columns: repeat(8, 1fr);
-      padding-top: 40px;
     }
   }
   .project-summary {
     grid-column: 1 / -1;
+    margin-bottom: 16px;
     p {
       font-size: 1.25rem;
       color: $red;


### PR DESCRIPTION
When looking at https://github.com/hotosm/hotosm-website/issues/299, it seems that project content was vertically centered (separating it from the project summary) if there was extra space created by a long sidebar. Something I had not tested.

**Before**

<img width="1326" alt="screenshot 2018-06-12 10 52 17" src="https://user-images.githubusercontent.com/1270986/41283691-2d804378-6e2f-11e8-893d-50d70a8c1995.png">

**After**

<img width="1328" alt="screenshot 2018-06-12 10 50 06" src="https://user-images.githubusercontent.com/1270986/41283708-3509d410-6e2f-11e8-98df-49027345c867.png">
