### PR TITLE
reverse order of recently closed

### DIFF
--- a/_layouts/groups.html
+++ b/_layouts/groups.html
@@ -74,7 +74,8 @@ layout: default
 
             <h4>Recently closed jobs</h4>
 
-            {% for job in jobs_sorted limit: 3 %}
+            {% assign jobs_closed = site.jobs | sort: 'Deadline Date' | reverse %}
+            {% for job in jobs_closed limit: 6 %}
               {% assign job_date = job['Deadline Date'] | date: '%Y%m%d' %}
               {% if job_date <= current_date %}
               <a href="{{ job.url }}" class="module light link-through">


### PR DESCRIPTION
Bumps up the number of jobs shown on recently closed and reverses the order to show most recently closed first: 

<img width="1007" alt="humanitarian openstreetmap team jobs 2018-07-09 16-20-44" src="https://user-images.githubusercontent.com/796838/42459696-20ce7bd4-8394-11e8-9979-1122ba0826cf.png">
