### PR TITLE
add meta tag for feed

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,6 +6,7 @@
   <title>{{ site.title }} | {{ page.title }}</title>
 
   <meta name="description" content="{% if page.Meta %}{{ page.Meta }}{% endif %}{% for tag in page.tags %}{% if forloop.last == true %}{{ tag }}{% else %}{{ tag }}, {% endif %}{% endfor %}">
+  {% feed_meta %}
 
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
 


### PR DESCRIPTION
Adds meta tag in head of all pages to help with atom feed discovery: https://github.com/jekyll/jekyll-feed#meta-tags. 