### PR TITLE
Format blog author list in home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -130,10 +130,13 @@
                               {% endif %}
                             {% endfor %}
                           {% endif %}
-                          {% capture post.Person %}{% endcapture %}
-                          {% assign author = site.people | where: "title", post.Person | first %}
+                          <!-- {% capture post.Person %}{% endcapture %} -->
+                          <!-- {% assign author = site.people | where: "title", post.Person | first %} -->
                           {% if post.Person %}
-                            {{ post.Person }}
+                          <!-- {% assign authors = post.Person | split: ", " %} -->
+                            {% for author in post.Person %}
+                              {{ author }}{% unless forloop.last %},{% endunless %}
+                            {% endfor %}
                           {% endif %}
                         </p>
                       </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -124,17 +124,13 @@
                             {% for country in post.Country %}
                               {% if country != '' %}
                                 {{ country }}{% unless forloop.last %},{% endunless %}
-                                {% if forloop.last %} - {% endif %}
                               {% else %}
-                                Global -
+                                Global
                               {% endif %}
                             {% endfor %}
                           {% endif %}
-                          <!-- {% capture post.Person %}{% endcapture %} -->
-                          <!-- {% assign author = site.people | where: "title", post.Person | first %} -->
                           {% if post.Person %}
-                          <!-- {% assign authors = post.Person | split: ", " %} -->
-                            {% for author in post.Person %}
+                            -{% for author in post.Person %}
                               {{ author }}{% unless forloop.last %},{% endunless %}
                             {% endfor %}
                           {% endif %}

--- a/updates/index.html
+++ b/updates/index.html
@@ -89,7 +89,13 @@ layout: default
               <div class="news-list-meta">
                 {% assign author = site.people | where: "title", post.Person | first %}
                   <p class="news-index-author">
-                    {% include author.html %} — {{ post.date | date: '%e %B, %Y' }}</p>
+                    {% if post.Person %}
+                      {% for author in post.Person %}
+                        {{ author }}{% unless forloop.last %},{% endunless %}
+                        {% if forloop.last %} - {% endif %}
+                      {% endfor %}
+                    {% endif %}
+                    {{ post.date | date: '%e %B, %Y' }}</p>
                       {% if post.Country != '' %}
                         <p class="news-index-country">
                           {% for country in post.Country %}


### PR DESCRIPTION
Includes the following changes:

- [x] Format author list in home page & news page
- [x] Remove `-` when there's no author mentioned 
  - after the country list in home page
  - before the date entry in news list

![image](https://user-images.githubusercontent.com/12103383/44024280-79aacc58-9f0a-11e8-8fe3-ecbee0ee6750.png)

![image](https://user-images.githubusercontent.com/12103383/44024450-ef6cc982-9f0a-11e8-9f40-3b49710ba727.png)

cc @TylerRadford @smit1678 