### PR TITLE
fix global roster section to not exclude turkey, add turkey to sila

### DIFF
--- a/_layouts/roster-staff.html
+++ b/_layouts/roster-staff.html
@@ -63,7 +63,7 @@ layout: default
                 <h2>Global</h2>
                 <div class="roster-list-wrapper">
                 {% for person in sorted-people %}
-                {% if person.Country != 'Botswana' and person.Country != 'Turkey' and person.Country != 'Uganda' and person.Country != 'Tanzania' and person.Country != 'Indonesia' and person['Member Type']['Is Staff'] %}
+                {% if person.Country != 'Botswana' and person.Country != 'Uganda' and person.Country != 'Tanzania' and person.Country != 'Indonesia' and person['Member Type']['Is Staff'] %}
 
                 {% include blocks/roster-item.html %}
                 {% endif %}

--- a/_people/sila-alici.markdown
+++ b/_people/sila-alici.markdown
@@ -5,6 +5,7 @@ Photo: "/uploads/sila2.jpg"
 Member Type:
   Is Staff: true
 Job Title: Communications Manager
+Country: Turkey
 Working Group:
 - Communications
 Social Media (Full URL):


### PR DESCRIPTION
Fixes an issue where staff tagged as Turkey were not showing up in the global section. 