### PR TITLE
adds a privacy policy page with draft text, fix #389

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,6 +19,7 @@
         <a href="/contact">Contact</a>
         <a href="/jobs">Jobs</a>
         <a href="/code-of-conduct">Code of conduct</a>
+        <a href="/privacy">Privacy Policy</a>
       </div>
       {% include social-links.html %}
     </nav>

--- a/privacy.md
+++ b/privacy.md
@@ -1,0 +1,11 @@
+---
+title: Privacy Policy
+layout: page
+Intro Text: Our privacy policy covers what personal data we collect, how we use personal data, and the options that you have regarding the collection and use. Keep reading to learn more. 
+Page Contact:
+  Label: Contact HOT
+  Text: Have a question about the Privacy Policy?
+  Contact Email: sysadmin@hotosm.org
+---
+
+Our Privacy Policy is currently under review. A [draft version](https://github.com/hotosm/legal) is accessible online for reading and downloading. 


### PR DESCRIPTION
Adds: 

* new `/privacy` page with text for draft policy and links to Github
* footer link to `/privacy`

<img width="1391" alt="humanitarian openstreetmap team privacy policy 2019-01-07 11-55-54" src="https://user-images.githubusercontent.com/796838/50748227-48987200-1273-11e9-894b-13d084f5afde.png">

Footer is getting quite tall and so it would be good to review and see how we could optimize the space. Will break out a separate ticket for that. 