### PR TITLE
Format country display in news preview

### DIFF
--- a/_posts/2018-10-17-participatory-mapping-toolkit-a-guide-for-refugee-contexts.markdown
+++ b/_posts/2018-10-17-participatory-mapping-toolkit-a-guide-for-refugee-contexts.markdown
@@ -6,7 +6,6 @@ Person: William Evans
 Country:
 - Uganda
 - Turkey
-- 
 ---
 
 The world continues to witness some of the highest levels of displacement on record, with nearly **70 million people** who have been forced from their homes. At Humanitarian OpenStreetMap Team, we have been using participatory mapping to assist in these refugee contexts. Our aims are simple: **save lives, alleviate suffering, and restore dignity.** [The Toolkit](https://www.hotosm.org/resources/participatory-mapping-toolkit/) is meant for organizations and individuals working towards these same ends - it is field-derived, fundamentally responsive to people’s needs, and written so that anyone can pick it up and begin using open mapping for humanitarian action. 

--- a/_posts/2018-10-17-tylers-new-draft-blog-post.markdown
+++ b/_posts/2018-10-17-tylers-new-draft-blog-post.markdown
@@ -1,6 +1,0 @@
----
-title: Tyler's new draft blog post
-date: 2018-10-17 02:13:00 Z
-published: false
----
-

--- a/updates/index.html
+++ b/updates/index.html
@@ -39,7 +39,13 @@ layout: default
                 <p class="news-index-country">
                   {% for country in post.Country %}
                     {% if country != '' %}
-                      {{ country }}{% unless forloop.last %},{% endunless %}
+                      {% if post.Country.size <= 3 %}
+                        {{ country }}{% unless forloop.last and country != '' %}, {% endunless %}
+                      {% else post.Country.size > 3 %}
+                        {% assign countrycount = post.Country.size %}
+                        {{ post.Country[0] }} and {{ countrycount | minus: 1 }} other countries
+                        {% break %}
+                     {% endif %}
                     {% else %}
                       Global
                     {% endif %}
@@ -98,13 +104,19 @@ layout: default
                     {{ post.date | date: '%e %B, %Y' }}</p>
                       {% if post.Country != '' %}
                         <p class="news-index-country">
-                          {% for country in post.Country %}
-                            {% if country != '' %}
-                              {{ country }}{% unless forloop.last %},{% endunless %}
-                            {% else %}
-                              Global
-                            {% endif %}
-                          {% endfor %}
+                            {% for country in post.Country %}
+                              {% if country != '' %}
+                                {% if post.Country.size <= 3 %}
+                                  {{ country }}{% unless forloop.last %}, {% endunless %}
+                                {% else post.Country.size > 3 %}
+                                  {% assign countrycount = post.Country.size %}
+                                   {{ post.Country[0] }} and {{ countrycount | minus: 1 }} other countries
+                                  {% break %}
+                               {% endif %}
+                              {% else %}
+                                Global
+                              {% endif %}
+                            {% endfor %}
                         </p>
                       {% endif %}
               </div>


### PR DESCRIPTION
Per discussion w/ @smit1678 [here](https://github.com/hotosm/hotosm-website/pull/381#issuecomment-436264344), updating the country display in new preview. If the number of countries is > 3, then we just specify the first item, followed by the count.

### Current display

![image](https://user-images.githubusercontent.com/12103383/51242775-7c7e4080-19b3-11e9-8b32-c76a9a33bd1b.png)

### Changes made
![image](https://user-images.githubusercontent.com/12103383/51242946-d3841580-19b3-11e9-87ee-fb8ed3fca899.png)

Also cleaned up an empty file and an empty item in one of the posts. More in a ticket on how to handle empty items in front matter.
