### PR TITLE
Job will move to closed after, not on, deadline

### DIFF
--- a/_layouts/groups.html
+++ b/_layouts/groups.html
@@ -77,7 +77,7 @@ layout: default
             {% assign jobs_closed = site.jobs | sort: 'Deadline Date' | reverse %}
             {% for job in jobs_closed limit: 6 %}
               {% assign job_date = job['Deadline Date'] | date: '%Y%m%d' %}
-              {% if job_date <= current_date %}
+              {% if job_date < current_date %}
               <a href="{{ job.url }}" class="module light link-through">
                 <div class="module-details">
                   <h3>{{ job.title }}</h3>


### PR DESCRIPTION
Thanks @TylerRadford for pointing this out. 

Currently a job will show up as both open and closed on the day of the deadline, which was fixed with a simple edit to the logic. 

Current:
![image 1](https://user-images.githubusercontent.com/1847818/51275351-b34a5b80-199f-11e9-9710-b83ddd71769a.png)

New: 

![image](https://user-images.githubusercontent.com/1847818/51275340-a9c0f380-199f-11e9-9b6e-630f0ba99b6b.png)
