### PR TITLE
Improve author list formatting #421

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,7 +1,10 @@
 {% assign author = site.people | where: "title", post.Person | first %}
 
-{% if post.Person == author.title %}
-  <a class="author-link" href="{{ author.url}}">{{ author.title }}</a>
-{% elsif post.Person %}
-  {{ post.Person }}
+{% if post.Person %}
+   {% if post.Person == author.title %}
+      <a class="author-link" href="{{ author.url}}">{{ author.title }}</a>
+   {% elsif post.Person %}
+      {{ post.Person | join :','}}
+    {% endif %}
+   —
 {% endif %}

--- a/_layouts/project-item.html
+++ b/_layouts/project-item.html
@@ -245,7 +245,7 @@ layout: default
                             {% capture post.Person %}{% endcapture %}
                             <div class="news-list-meta">
                                 <p class="news-index-author">
-                                    {% include author.html %} — {{ post.date | date: '%e %B, %Y' }}
+                                    {% include author.html %}  {{ post.date | date: '%e %B, %Y' }}
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
![Screenshot from 2019-03-13 12-58-56](https://user-images.githubusercontent.com/42279758/54285375-d708d700-45c7-11e9-8d83-13580e4eeb47.png)

As mentioned in Issue #421 , i have fixed those issues, working Screenshot is attached with this  PR. 
there is no leading `-` in case of empty author list and Multiple authors name is now comma separated.