### PR TITLE
Improve author list formatting for project pages

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,7 +1,13 @@
 {% assign author = site.people | where: "title", post.Person | first %}
 
-{% if post.Person == author.title %}
-  <a class="author-link" href="{{ author.url}}">{{ author.title }}</a>
-{% elsif post.Person %}
-  {{ post.Person }}
+{% if post.Person %}
+  {% for person in post.Person %}
+    {% if post.Person == author.title %}
+      <a class="author-link" href="{{ author.url}}">{{ author.title }}</a>
+      {% unless forloop.last %}, {% endunless %}
+    {% else %}
+      {{ person }}{% unless forloop.last %}, {% endunless %}
+    {% endif %}
+  {% endfor %}
+  —
 {% endif %}

--- a/_layouts/project-item.html
+++ b/_layouts/project-item.html
@@ -245,7 +245,7 @@ layout: default
                             {% capture post.Person %}{% endcapture %}
                             <div class="news-list-meta">
                                 <p class="news-index-author">
-                                    {% include author.html %} — {{ post.date | date: '%e %B, %Y' }}
+                                    {% include author.html %} {{ post.date | date: '%e %B, %Y' }}
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
Fix #421. It handles empty author fields and also separates authors by a comma.
![hotosmwebsiteissue421](https://user-images.githubusercontent.com/32809190/54295742-a6319d80-45d9-11e9-8531-eb4a1fc51f18.png)
