### PR TITLE
Footer error removed

### DIFF
--- a/_layouts/groups.html
+++ b/_layouts/groups.html
@@ -128,11 +128,9 @@ layout: default
               </a>
               {% endif %}
             {% endfor %}
-
-
-          {% endif %}
-
         </div>
+        
+        {% endif %}
 
       </div>
 


### PR DESCRIPTION
Fixes #440 

The footer hyperlinks of `Site Login & Documentation` and `Working Groups` pages are active now.
@smit1678 @ramyaragupathy Kindly review this.