### PR TITLE
Fix overlapping content #427

### DIFF
--- a/_layouts/tools-and-data.html
+++ b/_layouts/tools-and-data.html
@@ -25,7 +25,7 @@ layout: default
 
   <div class="half-blocks">
 
-    <div class="half-block dark right">
+    <div class="half-block dark left">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 1'].Header }}</h3>
@@ -46,7 +46,7 @@ layout: default
       </div>
     </div>
 
-    <div class="half-block dark left ">
+    <div class="half-block dark right">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 2'].Header }}</h3>
@@ -67,7 +67,7 @@ layout: default
       </div>
     </div>
 
-    <div class="half-block dark right">
+    <div class="half-block dark left">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 3'].Header }}</h3>
@@ -88,7 +88,7 @@ layout: default
       </div>
     </div>
 
-    <div class="half-block dark left">
+    <div class="half-block dark right">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 4'].Header }}</h3>
@@ -109,7 +109,7 @@ layout: default
       </div>
     </div>
 
-    <div class="half-block dark right">
+    <div class="half-block dark left">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 5'].Header }}</h3>
@@ -130,7 +130,7 @@ layout: default
       </div>
     </div>
 
-    <div class="half-block dark left">
+    <div class="half-block dark right">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 6'].Header }}</h3>

--- a/_layouts/tools-and-data.html
+++ b/_layouts/tools-and-data.html
@@ -25,7 +25,7 @@ layout: default
 
   <div class="half-blocks">
 
-    <div class="half-block dark">
+    <div class="half-block dark right">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 1'].Header }}</h3>
@@ -46,7 +46,7 @@ layout: default
       </div>
     </div>
 
-    <div class="half-block right dark">
+    <div class="half-block dark left ">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 2'].Header }}</h3>
@@ -67,7 +67,7 @@ layout: default
       </div>
     </div>
 
-    <div class="half-block dark">
+    <div class="half-block dark right">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 3'].Header }}</h3>
@@ -88,7 +88,7 @@ layout: default
       </div>
     </div>
 
-    <div class="half-block dark right">
+    <div class="half-block dark left">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 4'].Header }}</h3>
@@ -109,7 +109,7 @@ layout: default
       </div>
     </div>
 
-    <div class="half-block dark">
+    <div class="half-block dark right">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 5'].Header }}</h3>
@@ -130,7 +130,7 @@ layout: default
       </div>
     </div>
 
-    <div class="half-block dark right">
+    <div class="half-block dark left">
       <div class="block-details">
         <div class="block-info">
           <h3>{{ page['Block 6'].Header }}</h3>

--- a/_layouts/what-we-do.html
+++ b/_layouts/what-we-do.html
@@ -4,189 +4,172 @@ layout: default
 
 <div class="what-we-do">
 
-    <header class="container what-we-do-header">
-      <h1>{{ page.title }}</h1>
-      <div class="intro">
-        <div class="intro-text">
-          {{ content }}
-        </div>
-        <div class="intro-btns">
-          <a href="{{ page['Primary Button'].URL }}" class="btn btn-primary btn-block btn-lg btn-chevron">{{ page['Primary Button'].Words }}</a>
-          <a href="{{ page['Secondary Button'].URL }}" class="btn btn-default btn-block btn-lg btn-chevron">{{ page['Secondary Button'].Words }}</a>
-        </div>
+  <header class="container what-we-do-header">
+    <h1>{{ page.title }}</h1>
+    <div class="intro">
+      <div class="intro-text">
+        {{ content }}
       </div>
-    </header>
-  
-    
-  <div>
-    <div class="half-blocks">
-        <div class="half-block dark left">
-          <div class="block-details left">
-            <div class="block-info">
-              <h3>{{ page['Block 1'].Header }}</h3>
-              <p>{{ page['Block 1'].Text }}</p>
-            </div>
-            <div class="block-options">
-              <h5>Projects to check out</h5>
-              <ul>
-                {% for project in page['Block 1'].Project %}
-    
-                  {% comment %}
-                    The for loop below seems to be required to get the project url
-                  {% endcomment %}
-    
-                  {% for p in site.projects %}
-                    {% if p.title == project %}
-                        {% capture pURL %} {{p.url}} {% endcapture %}
-                        {% break %}     
-                    {% endif %}
-                  {% endfor %}
-                  <li><a href="{{ pURL }}">{{ project }}</a></li>
-                {% endfor %}
-              </ul>
-            </div>
-            
-          </div>
-          <div class="block-image right">
-            <img src="{{ page['Block 1'].Image }}">
-          </div>
+      <div class="intro-btns">
+        <a href="{{ page['Primary Button'].URL }}" class="btn btn-primary btn-block btn-lg btn-chevron">{{ page['Primary Button'].Words }}</a>
+        <a href="{{ page['Secondary Button'].URL }}" class="btn btn-default btn-block btn-lg btn-chevron">{{ page['Secondary Button'].Words }}</a>
+      </div>
+    </div>
+  </header>
+
+  <div class="half-blocks">
+
+    <div class="half-block dark left">
+      <div class="block-details left">
+        <div class="block-info">
+          <h3>{{ page['Block 1'].Header }}</h3>
+          <p>{{ page['Block 1'].Text }}</p>
         </div>
-      
-      
-  
+        <div class="block-options">
+          <h5>Projects to check out</h5>
+          <ul>
+            {% for project in page['Block 1'].Project %}
 
-      <div class="half-block dark right">
-        <div class="block-details right">
-          <div class="block-info">
-            <h3>{{ page['Block 2'].Header }}</h3>
-            <p>{{ page['Block 2'].Text }}</p>
-          </div>
-          <div class="block-options">
-            <h5>Projects to check out</h5>
-            <ul>
-              {% for project in page['Block 2'].Project %}
-              
               {% comment %}
-                  The for loop below seems to be required to get the project url
-                  {% endcomment %}
-                  
-                  {% for p in site.projects %}
-                  {% if p.title == project %}
-                  {% capture pURL %} {{p.url}} {% endcapture %}
-                      {% break %}     
-                      {% endif %}
-                      {% endfor %}
-                      <li><a href="{{ pURL }}">{{ project }}</a></li>
-                      {% endfor %}
-                    </ul>
-            </div>
-          </div>
-               <div class="block-image left">
-                      <img src="{{ page['Block 2'].Image }}">
-                </div>
-                
-         </div>
-              
-    
-            
-
-      <div class="half-block dark left">
-        
-        <div class="block-details left">
-          <div class="block-info">
-            <h3>{{ page['Block 3'].Header }}</h3>
-            <p>{{ page['Block 3'].Text }}</p>
-          </div>
-          <div class="block-options">
-            <h5>Projects to check out</h5>
-            <ul>
-              {% for project in page['Block 3'].Project %}
-              
-              {% comment %}
-              The for loop below seems to be required to get the project url
+                The for loop below seems to be required to get the project url
               {% endcomment %}
-              
+
               {% for p in site.projects %}
-              {% if p.title == project %}
-              {% capture pURL %} {{p.url}} {% endcapture %}
-              {% break %}     
-              {% endif %}
+                {% if p.title == project %}
+                    {% capture pURL %} {{p.url}} {% endcapture %}
+                    {% break %}     
+                {% endif %}
               {% endfor %}
               <li><a href="{{ pURL }}">{{ project }}</a></li>
-              {% endfor %}
-            </ul>
-          </div>
-        </div>
-            <div class="block-image right">
-              <img src="{{ page['Block 3'].Image }}">
-            </div>
-        
-      </div>
-      
-      
-      <div class="half-block dark right ">
-        <div class="block-details right">
-          <div class="block-info">
-            <h3>{{ page['Block 4'].Header }}</h3>
-            <p>{{ page['Block 4'].Text }}</p>
-          </div>
-          <div class="block-options">
-            <h5>Projects to check out</h5>
-            <ul>
-              {% for project in page['Block 4'].Project %}
-  
-                {% comment %}
-                  The for loop below seems to be required to get the project url
-                {% endcomment %}
-  
-                {% for p in site.projects %}
-                  {% if p.title == project %}
-                      {% capture pURL %} {{p.url}} {% endcapture %}
-                      {% break %}     
-                  {% endif %}
-                {% endfor %}
-                <li><a href="{{ pURL }}">{{ project }}</a></li>
-              {% endfor %}
-            </ul>
-          </div>
-        </div>
-        <div class="block-image left">
-          <img src="{{ page['Block 4'].Image }}">
-        </div>
-       
-      </div>
-      
-      <div class="half-block dark left">
-        <div class="block-details left">
-          <div class="block-info">
-            <h3>{{ page['Block 5'].Header }}</h3>
-            <p>{{ page['Block 5'].Text }}</p>
-          </div>
-          <div class="block-options">
-            <h5>Learn more about OpenStreetMap</h5>
-            <ul>
-              {% for link in page['Block 5'].Links %}
-                <li>{{ link }}</li>
-              {% endfor %}
-            </ul>
-          </div>
-        </div> 
-        <div class="block-screenshot right">
-            <div class="block-screenshot-wrap">
-              <img src="{{ page['Block 5'].Image }}">
-            </div>
+            {% endfor %}
+          </ul>
         </div>
       </div>
-     
+      <div class="block-image right">
+        <img src="{{ page['Block 1'].Image }}">
+      </div>
     </div>
 
-  <div class="container right"  >
-      {% include impact-areas.html %}
-      <div class="hr-h"></div>
+    <div class="half-block right dark">
+      <div class="block-details right">
+        <div class="block-info">
+          <h3>{{ page['Block 2'].Header }}</h3>
+          <p>{{ page['Block 2'].Text }}</p>
+        </div>
+        <div class="block-options">
+          <h5>Projects to check out</h5>
+          <ul>
+            {% for project in page['Block 2'].Project %}
+              
+              {% comment %}
+                The for loop below seems to be required to get the project url
+              {% endcomment %}
+
+              {% for p in site.projects %}
+                {% if p.title == project %}
+                    {% capture pURL %} {{p.url}} {% endcapture %}
+                    {% break %}     
+                {% endif %}
+              {% endfor %}
+              <li><a href="{{ pURL }}">{{ project }}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+      <div class="block-image left">
+        <img src="{{ page['Block 2'].Image }}">
+      </div>
+    </div>
+
+    <div class="half-block dark left">
+      <div class="block-details left">
+        <div class="block-info">
+          <h3>{{ page['Block 3'].Header }}</h3>
+          <p>{{ page['Block 3'].Text }}</p>
+        </div>
+        <div class="block-options">
+          <h5>Projects to check out</h5>
+          <ul>
+            {% for project in page['Block 3'].Project %}
+
+              {% comment %}
+                The for loop below seems to be required to get the project url
+              {% endcomment %}
+
+              {% for p in site.projects %}
+                {% if p.title == project %}
+                    {% capture pURL %} {{p.url}} {% endcapture %}
+                    {% break %}     
+                {% endif %}
+              {% endfor %}
+              <li><a href="{{ pURL }}">{{ project }}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+      <div class="block-image right">
+        <img src="{{ page['Block 3'].Image }}">
+      </div>
+    </div>
+
+    <div class="half-block right dark">
+      <div class="block-details right">
+        <div class="block-info">
+          <h3>{{ page['Block 4'].Header }}</h3>
+          <p>{{ page['Block 4'].Text }}</p>
+        </div>
+        <div class="block-options">
+          <h5>Projects to check out</h5>
+          <ul>
+            {% for project in page['Block 4'].Project %}
+
+              {% comment %}
+                The for loop below seems to be required to get the project url
+              {% endcomment %}
+
+              {% for p in site.projects %}
+                {% if p.title == project %}
+                    {% capture pURL %} {{p.url}} {% endcapture %}
+                    {% break %}     
+                {% endif %}
+              {% endfor %}
+              <li><a href="{{ pURL }}">{{ project }}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+      <div class="block-image left">
+        <img src="{{ page['Block 4'].Image }}">
+      </div>
+    </div>
+
+    <div class="half-block dark left">
+      <div class="block-details left">
+        <div class="block-info">
+          <h3>{{ page['Block 5'].Header }}</h3>
+          <p>{{ page['Block 5'].Text }}</p>
+        </div>
+        <div class="block-options">
+          <h5>Learn more about OpenStreetMap</h5>
+          <ul>
+            {% for link in page['Block 5'].Links %}
+              <li>{{ link }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+      <div class="block-screenshot right">
+        <div class="block-screenshot-wrap">
+          <img src="{{ page['Block 5'].Image }}">
+        </div>
+      </div>
+    </div>
+
   </div>
+
+  <div class="container right">
+    {% include impact-areas.html %}
+    <div class="hr-h"></div>
+  </div>
+
 </div>
-  i
-  
-</div>
-     
-  

--- a/_layouts/what-we-do.html
+++ b/_layouts/what-we-do.html
@@ -4,172 +4,189 @@ layout: default
 
 <div class="what-we-do">
 
-  <header class="container what-we-do-header">
-    <h1>{{ page.title }}</h1>
-    <div class="intro">
-      <div class="intro-text">
-        {{ content }}
-      </div>
-      <div class="intro-btns">
-        <a href="{{ page['Primary Button'].URL }}" class="btn btn-primary btn-block btn-lg btn-chevron">{{ page['Primary Button'].Words }}</a>
-        <a href="{{ page['Secondary Button'].URL }}" class="btn btn-default btn-block btn-lg btn-chevron">{{ page['Secondary Button'].Words }}</a>
-      </div>
-    </div>
-  </header>
-
-  <div class="half-blocks">
-
-    <div class="half-block dark">
-      <div class="block-details">
-        <div class="block-info">
-          <h3>{{ page['Block 1'].Header }}</h3>
-          <p>{{ page['Block 1'].Text }}</p>
+    <header class="container what-we-do-header">
+      <h1>{{ page.title }}</h1>
+      <div class="intro">
+        <div class="intro-text">
+          {{ content }}
         </div>
-        <div class="block-options">
-          <h5>Projects to check out</h5>
-          <ul>
-            {% for project in page['Block 1'].Project %}
-
-              {% comment %}
-                The for loop below seems to be required to get the project url
-              {% endcomment %}
-
-              {% for p in site.projects %}
-                {% if p.title == project %}
-                    {% capture pURL %} {{p.url}} {% endcapture %}
-                    {% break %}     
-                {% endif %}
-              {% endfor %}
-              <li><a href="{{ pURL }}">{{ project }}</a></li>
-            {% endfor %}
-          </ul>
+        <div class="intro-btns">
+          <a href="{{ page['Primary Button'].URL }}" class="btn btn-primary btn-block btn-lg btn-chevron">{{ page['Primary Button'].Words }}</a>
+          <a href="{{ page['Secondary Button'].URL }}" class="btn btn-default btn-block btn-lg btn-chevron">{{ page['Secondary Button'].Words }}</a>
         </div>
       </div>
-      <div class="block-image">
-        <img src="{{ page['Block 1'].Image }}">
-      </div>
-    </div>
-
-    <div class="half-block right dark">
-      <div class="block-details">
-        <div class="block-info">
-          <h3>{{ page['Block 2'].Header }}</h3>
-          <p>{{ page['Block 2'].Text }}</p>
+    </header>
+  
+    
+  <div>
+    <div class="half-blocks">
+        <div class="half-block dark left">
+          <div class="block-details left">
+            <div class="block-info">
+              <h3>{{ page['Block 1'].Header }}</h3>
+              <p>{{ page['Block 1'].Text }}</p>
+            </div>
+            <div class="block-options">
+              <h5>Projects to check out</h5>
+              <ul>
+                {% for project in page['Block 1'].Project %}
+    
+                  {% comment %}
+                    The for loop below seems to be required to get the project url
+                  {% endcomment %}
+    
+                  {% for p in site.projects %}
+                    {% if p.title == project %}
+                        {% capture pURL %} {{p.url}} {% endcapture %}
+                        {% break %}     
+                    {% endif %}
+                  {% endfor %}
+                  <li><a href="{{ pURL }}">{{ project }}</a></li>
+                {% endfor %}
+              </ul>
+            </div>
+            
+          </div>
+          <div class="block-image right">
+            <img src="{{ page['Block 1'].Image }}">
+          </div>
         </div>
-        <div class="block-options">
-          <h5>Projects to check out</h5>
-          <ul>
-            {% for project in page['Block 2'].Project %}
+      
+      
+  
+
+      <div class="half-block dark right">
+        <div class="block-details right">
+          <div class="block-info">
+            <h3>{{ page['Block 2'].Header }}</h3>
+            <p>{{ page['Block 2'].Text }}</p>
+          </div>
+          <div class="block-options">
+            <h5>Projects to check out</h5>
+            <ul>
+              {% for project in page['Block 2'].Project %}
               
               {% comment %}
-                The for loop below seems to be required to get the project url
-              {% endcomment %}
+                  The for loop below seems to be required to get the project url
+                  {% endcomment %}
+                  
+                  {% for p in site.projects %}
+                  {% if p.title == project %}
+                  {% capture pURL %} {{p.url}} {% endcapture %}
+                      {% break %}     
+                      {% endif %}
+                      {% endfor %}
+                      <li><a href="{{ pURL }}">{{ project }}</a></li>
+                      {% endfor %}
+                    </ul>
+            </div>
+          </div>
+               <div class="block-image left">
+                      <img src="{{ page['Block 2'].Image }}">
+                </div>
+                
+         </div>
+              
+    
+            
 
-              {% for p in site.projects %}
-                {% if p.title == project %}
-                    {% capture pURL %} {{p.url}} {% endcapture %}
-                    {% break %}     
-                {% endif %}
-              {% endfor %}
-              <li><a href="{{ pURL }}">{{ project }}</a></li>
-            {% endfor %}
-          </ul>
-        </div>
-      </div>
-      <div class="block-image">
-        <img src="{{ page['Block 2'].Image }}">
-      </div>
-    </div>
-
-    <div class="half-block dark">
-      <div class="block-details">
-        <div class="block-info">
-          <h3>{{ page['Block 3'].Header }}</h3>
-          <p>{{ page['Block 3'].Text }}</p>
-        </div>
-        <div class="block-options">
-          <h5>Projects to check out</h5>
-          <ul>
-            {% for project in page['Block 3'].Project %}
-
+      <div class="half-block dark left">
+        
+        <div class="block-details left">
+          <div class="block-info">
+            <h3>{{ page['Block 3'].Header }}</h3>
+            <p>{{ page['Block 3'].Text }}</p>
+          </div>
+          <div class="block-options">
+            <h5>Projects to check out</h5>
+            <ul>
+              {% for project in page['Block 3'].Project %}
+              
               {% comment %}
-                The for loop below seems to be required to get the project url
+              The for loop below seems to be required to get the project url
               {% endcomment %}
-
+              
               {% for p in site.projects %}
-                {% if p.title == project %}
-                    {% capture pURL %} {{p.url}} {% endcapture %}
-                    {% break %}     
-                {% endif %}
+              {% if p.title == project %}
+              {% capture pURL %} {{p.url}} {% endcapture %}
+              {% break %}     
+              {% endif %}
               {% endfor %}
               <li><a href="{{ pURL }}">{{ project }}</a></li>
-            {% endfor %}
-          </ul>
-        </div>
-      </div>
-      <div class="block-image">
-        <img src="{{ page['Block 3'].Image }}">
-      </div>
-    </div>
-
-    <div class="half-block right dark">
-      <div class="block-details">
-        <div class="block-info">
-          <h3>{{ page['Block 4'].Header }}</h3>
-          <p>{{ page['Block 4'].Text }}</p>
-        </div>
-        <div class="block-options">
-          <h5>Projects to check out</h5>
-          <ul>
-            {% for project in page['Block 4'].Project %}
-
-              {% comment %}
-                The for loop below seems to be required to get the project url
-              {% endcomment %}
-
-              {% for p in site.projects %}
-                {% if p.title == project %}
-                    {% capture pURL %} {{p.url}} {% endcapture %}
-                    {% break %}     
-                {% endif %}
               {% endfor %}
-              <li><a href="{{ pURL }}">{{ project }}</a></li>
-            {% endfor %}
-          </ul>
+            </ul>
+          </div>
+        </div>
+            <div class="block-image right">
+              <img src="{{ page['Block 3'].Image }}">
+            </div>
+        
+      </div>
+      
+      
+      <div class="half-block dark right ">
+        <div class="block-details right">
+          <div class="block-info">
+            <h3>{{ page['Block 4'].Header }}</h3>
+            <p>{{ page['Block 4'].Text }}</p>
+          </div>
+          <div class="block-options">
+            <h5>Projects to check out</h5>
+            <ul>
+              {% for project in page['Block 4'].Project %}
+  
+                {% comment %}
+                  The for loop below seems to be required to get the project url
+                {% endcomment %}
+  
+                {% for p in site.projects %}
+                  {% if p.title == project %}
+                      {% capture pURL %} {{p.url}} {% endcapture %}
+                      {% break %}     
+                  {% endif %}
+                {% endfor %}
+                <li><a href="{{ pURL }}">{{ project }}</a></li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+        <div class="block-image left">
+          <img src="{{ page['Block 4'].Image }}">
+        </div>
+       
+      </div>
+      
+      <div class="half-block dark left">
+        <div class="block-details left">
+          <div class="block-info">
+            <h3>{{ page['Block 5'].Header }}</h3>
+            <p>{{ page['Block 5'].Text }}</p>
+          </div>
+          <div class="block-options">
+            <h5>Learn more about OpenStreetMap</h5>
+            <ul>
+              {% for link in page['Block 5'].Links %}
+                <li>{{ link }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div> 
+        <div class="block-screenshot right">
+            <div class="block-screenshot-wrap">
+              <img src="{{ page['Block 5'].Image }}">
+            </div>
         </div>
       </div>
-      <div class="block-image">
-        <img src="{{ page['Block 4'].Image }}">
-      </div>
+     
     </div>
 
-    <div class="half-block dark">
-      <div class="block-details">
-        <div class="block-info">
-          <h3>{{ page['Block 5'].Header }}</h3>
-          <p>{{ page['Block 5'].Text }}</p>
-        </div>
-        <div class="block-options">
-          <h5>Learn more about OpenStreetMap</h5>
-          <ul>
-            {% for link in page['Block 5'].Links %}
-              <li>{{ link }}</li>
-            {% endfor %}
-          </ul>
-        </div>
-      </div>
-      <div class="block-screenshot">
-        <div class="block-screenshot-wrap">
-          <img src="{{ page['Block 5'].Image }}">
-        </div>
-      </div>
-    </div>
-
+  <div class="container right"  >
+      {% include impact-areas.html %}
+      <div class="hr-h"></div>
   </div>
-
-  <div class="container">
-    {% include impact-areas.html %}
-    <div class="hr-h"></div>
-  </div>
-
 </div>
+  i
+  
+</div>
+     
+  

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -80,7 +80,7 @@ h2 {
 }
 
 h3 {
-  font-size: 1.25rem;
+  font-size: 1.75rem;
   line-height: 1.3;
   margin: 0 0 12px;
   color: $blue-dark;
@@ -129,7 +129,7 @@ a {
 
 p {
   color: $blue-grey;
-  line-height: 1.05;
+  line-height: 1.35;
 }
 
 img {
@@ -706,6 +706,7 @@ em {
   grid-gap: 0;
   grid-template-columns: repeat(12, 1fr);
   grid-template-rows: 400px;
+  overflow: hidden;
   border-radius: 2px;
   margin-bottom: 24px;
   background-color: shade($blue-dark, 20%);
@@ -1930,7 +1931,6 @@ em {
 .footer-copyright {
   background-color: shade($red, 50%);
   padding: 12px 0;
-  overflow: auto;
   .container {
     display: flex;
     align-items: center;
@@ -4413,7 +4413,6 @@ sup {
     }
   }
   .block-info {
-    padding: 0%;
     flex: 1;
   }
   .block-options {
@@ -4654,8 +4653,6 @@ sup {
   .block-screenshot {
     background-color: $blue-grey;
     background-size: cover;
-    width: 100%;
-    height: 100%;
     @media (max-width: $screen-sm) {
       padding: 64px 0 0 64px;
     }
@@ -4668,13 +4665,12 @@ sup {
     background-color: $white;
     border-top-left-radius: 5px;
     overflow: hidden;
-    width: 100%;
     height: 100%; 
     img {
-      display: block;
-      max-width: 140%;
-      width: 140%;
-      object-fit: contain;
+      max-width: 200%;
+      width: 100%;
+      max-height: 200%;
+      height:100%;
     }
   }
   &.dark {

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -4657,7 +4657,7 @@ sup {
       padding: 64px 0 0 64px;
     }
     @media (max-width: $screen-xs) {
-      padding: 32px 0 0 32px;
+      padding: 0px 0 0 0px;
     }
   }
   .block-screenshot-wrap {
@@ -4667,9 +4667,7 @@ sup {
     overflow: hidden;
     height: 100%; 
     img {
-      max-width: 200%;
       width: 100%;
-      max-height: 200%;
       height:100%;
     }
   }

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -4669,7 +4669,7 @@ sup {
     height: 100%; 
     img {
       max-width: 140%;
-      width: 100%;
+      width: 140%;
     }
   }
   &.dark {

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -80,7 +80,7 @@ h2 {
 }
 
 h3 {
-  font-size: 1.75rem;
+  font-size: 1.25rem;
   line-height: 1.3;
   margin: 0 0 12px;
   color: $blue-dark;
@@ -129,7 +129,7 @@ a {
 
 p {
   color: $blue-grey;
-  line-height: 1.35;
+  line-height: 1.05;
 }
 
 img {
@@ -249,6 +249,7 @@ em {
 
 .hr-h {
   min-width: 100%;
+  width: 100%;
   height: 1px;
   background-color: $border-color;
   margin: 40px 0 40px;
@@ -675,6 +676,7 @@ em {
 .container {
   padding: 0 16px;
   margin: 0 auto;
+  width: 100%;
   @media (min-width: $screen-xs) {
     padding: 0 40px;
   }
@@ -705,7 +707,6 @@ em {
   grid-template-columns: repeat(12, 1fr);
   grid-template-rows: 400px;
   border-radius: 2px;
-  overflow: hidden;
   margin-bottom: 24px;
   background-color: shade($blue-dark, 20%);
   @media (max-width: $screen-md) {
@@ -1854,6 +1855,8 @@ em {
 
 .site-footer {
   background-color: $red;
+  float: left;
+  width: 100%;
   h4 {
     color: $white;
   }
@@ -1927,6 +1930,7 @@ em {
 .footer-copyright {
   background-color: shade($red, 50%);
   padding: 12px 0;
+  overflow: auto;
   .container {
     display: flex;
     align-items: center;
@@ -4409,6 +4413,7 @@ sup {
     }
   }
   .block-info {
+    padding: 0%;
     flex: 1;
   }
   .block-options {
@@ -4647,9 +4652,10 @@ sup {
     }
   }
   .block-screenshot {
-    padding: 80px 0 0 80px;
     background-color: $blue-grey;
     background-size: cover;
+    width: 100%;
+    height: 100%;
     @media (max-width: $screen-sm) {
       padding: 64px 0 0 64px;
     }
@@ -4662,10 +4668,13 @@ sup {
     background-color: $white;
     border-top-left-radius: 5px;
     overflow: hidden;
-    height: 100%;
+    width: 100%;
+    height: 100%; 
     img {
+      display: block;
       max-width: 140%;
       width: 140%;
+      object-fit: contain;
     }
   }
   &.dark {

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -4651,13 +4651,14 @@ sup {
     }
   }
   .block-screenshot {
+    padding: 80px 0 0 80px;
     background-color: $blue-grey;
     background-size: cover;
     @media (max-width: $screen-sm) {
       padding: 64px 0 0 64px;
     }
     @media (max-width: $screen-xs) {
-      padding: 0px 0 0 0px;
+      padding: 32px 0 0 32px;
     }
   }
   .block-screenshot-wrap {
@@ -4667,8 +4668,8 @@ sup {
     overflow: hidden;
     height: 100%; 
     img {
+      max-width: 140%;
       width: 100%;
-      height:100%;
     }
   }
   &.dark {


### PR DESCRIPTION
Issues  solved:-
1) There was overlapping content in what-we-do and tools-and-data pages ,now  no overlapping content present in any page.
2) Links in What-we-do page were not working due to overlap,now it is also fixed.
3) In tools and data page Contact details and other information in docker was not visible due to overlap,now it is visible.


what-we-do page after changes:-
![Screen Shot 2019-03-15 at 18 25 16-fullpage](https://user-images.githubusercontent.com/42279758/54433188-40682180-4751-11e9-8f70-2a2223e822c9.png)


tools and data page earlier:-
![Screen Shot 2019-03-15 at 18 28 37-fullpage](https://user-images.githubusercontent.com/42279758/54433882-f2ecb400-4752-11e9-92ff-4cd0088c76c9.png)


tools and data page After Change:-
![Screen Shot 2019-03-15 at 18 39 20-fullpage](https://user-images.githubusercontent.com/42279758/54433376-b53b5b80-4751-11e9-95d0-0c268aa30932.png)



@ramyaragupathy  ,Kindly review  this pr .



