### PR TITLE
Drag property removed from some maps

### DIFF
--- a/js/countries-map.js
+++ b/js/countries-map.js
@@ -199,6 +199,7 @@ map.on('load', function() {
     }
     );
   map.on('mousemove', function(e) {
+    map.dragPan.disable();
     var projectHover = map.queryRenderedFeatures(
       e.point,
       {layers: ['country-projects-edits-circle', 'country-projects-black-circle', 'country-projects-symbol']}


### PR DESCRIPTION
Fixes #453 
The drag property is removed from maps in the affected section.

![hot2](https://user-images.githubusercontent.com/25206394/54542954-b921e480-49c2-11e9-8260-0945fbec967b.gif)

@ramyaragupathy Kindly review it and suggest changes if required.