### PR TITLE
Add jobs in search option

### DIFF
--- a/search.json
+++ b/search.json
@@ -40,7 +40,7 @@ layout:
 "type": "Job",
 "title": "{{ job.title | escape }}",
 "summary":"{{ job.body | escape | truncatewords : 40 | strip | prepend: ' ' }}",
-"subtitle":"Deadline: {{ job['Deadline Date'] }}",
+"subtitle":"Deadline: {{ job['Deadline Date'] | date_to_long_string }}",
 "url":"{{ site.url }}{{ job.url }}",
 "date":"{{ job.date }}"
 } {% unless forloop.last %},{% endunless %}

--- a/search.json
+++ b/search.json
@@ -33,6 +33,16 @@ layout:
 "subtitle":"{{ post.Person | join: ', ' }}",
 "url":"{{ site.url }}{{ post.url }}",
 "date":"{{ post.date }}"
+}, 
+{% endfor %}
+{% for job in site.jobs %}
+{
+"type": "Job",
+"title": "{{ job.title | escape }}",
+"summary":"{{ job.body | escape | truncatewords : 40 | strip | prepend: ' ' }}",
+"subtitle":"Deadline: {{ job['Deadline Date'] }}",
+"url":"{{ site.url }}{{ job.url }}",
+"date":"{{ job.date }}"
 } {% unless forloop.last %},{% endunless %}
 {% endfor %}
 ]


### PR DESCRIPTION
Fixes #412. Now jobs can be searched with the deadline date. 
@dakotabenjamin I have made the suggested changes. Please review this PR.