### PR TITLE
/where-we-work redirects to /our-wok

### DIFF
--- a/community.markdown
+++ b/community.markdown
@@ -3,6 +3,7 @@ title: Community & Organization
 date: 2018-02-06 15:20:00 Z
 permalink: "/community/"
 position: 5
+redirect_from: "/people"
 People:
   Description: The HOT community is made up of volunteers, local community leaders,
     and professionals committed to the mission of helping reach those in need through

--- a/our-work.markdown
+++ b/our-work.markdown
@@ -3,5 +3,6 @@ title: Our Work
 date: 2018-02-06 13:06:00 Z
 position: 2
 layout: project-index
+redirect_from: "/where-we-work"
 ---
 


### PR DESCRIPTION
Fixes #452

Now, hotosm.org/where-we-work will redirect to hotosm.org/our-work.html instead of giving Error 404. 