### PR TITLE
Fix anchor link on media-kit

### DIFF
--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -48,7 +48,8 @@ layout: default
 
       <div class="hr-h"></div>
 
-      <h2 id="media">Media</h2>
+      <div class="anchor" id="media"></div>
+      <h2>Media</h2>
       <div class="contact-persona">
         <div>
           {{ page.Media.Details | markdownify }}


### PR DESCRIPTION
Fixes #277 
As mentioned in the comments of #277, a similar nature of anchor link is seen on selecting `Media Kit` from  the footer.
The changes done are according to #511, to maintain the similarity in code-base.

@ramyaragupathy @smit1678 Kindly review.