### PR TITLE
Fix image auto resize problem

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -217,7 +217,7 @@ em {
     }
   }
   img {
-    width: 100%;
+    max-width: 100%;
     height: auto;
     & + em {
       font-size: 0.8125rem;


### PR DESCRIPTION
Fixes #529 . @smit1678 @dakotabenjamin Now the image takes it's original size if it's smaller than the div and gets resized only if image size is larger than the div.

![Screenshot from 2019-04-08 15-41-08](https://user-images.githubusercontent.com/43119923/55716745-619cf480-5a15-11e9-95ba-515f31d87c5a.jpg)
