### PR TITLE
add opt-out form to default template

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,5 +9,6 @@
         {% include footer.html %}
       </div>
     </div>
+    <div id="optout-form"></div>
   </body>
 </html>


### PR DESCRIPTION
This PR adds the opt-out form to the default template. We had only added the template to home.html and thus not rendered on all pages. Fixes matomo tracking across pages. 

cc @dakotabenjamin