### PR TITLE
add blockquote style for news posts

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -2212,6 +2212,14 @@ em {
     }
     .news-content {
       grid-column: 1 / -2;
+      blockquote {
+        padding: 24px;
+        background-color: $tan;
+        margin-bottom: 14px;
+      }
+      h2,h3 {
+        margin-top: 14px;
+      }
     }
   }
   .meta {


### PR DESCRIPTION
Adds a style for blockquotes on News posts. Added a margin adjustment in case a header line is included as well within the blockquotes. 

<img width="1011" alt="Humanitarian OpenStreetMap Team | Test 2019-06-10 08-33-15" src="https://user-images.githubusercontent.com/796838/59179789-0b564a00-8b5b-11e9-9b95-d8f840a89f7b.png">
