### PR TITLE
Track Finances PDF downloads

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -2,6 +2,6 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="{{ "/js/main.js" | prepend: site.baseurl }}"></script>
 <script type="application/javascript">var site_id=1;</script>
-<script src="https://cdn.hotosm.org/tracking-v1.js"></script>
+<script src="https://cdn.hotosm.org/tracking-v3.js"></script>
 {% if page.layout == 'home' %}<script src="{{ "/js/stats.js" | prepend: site.baseurl }}"></script>{% endif %}
 {% if page.layout == 'country' %}<script src="{{ "/js/countries-stats.js" | prepend: site.baseurl }}"></script>{% endif %}

--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -90,7 +90,7 @@ layout: default
           <div class="finances-text">
             <h3>Financials and Organization</h3>
             {{ page.Finances.Text | markdownify }}
-            <a href="{{ page.Finances['990 Report URL'] }}" class="btn btn-primary btn-block btn-download">{{ page.Finances['990 Report Button'] }}</a>
+            <a class='piwik_download' href="{{ page.Finances['990 Report URL'] }}" class="btn btn-primary btn-block btn-download">{{ page.Finances['990 Report Button'] }}</a>
           </div>
           <div class="annual-report">
             <h6>{{ page.Finances['Annual Report Header'] }}</h6>
@@ -100,7 +100,7 @@ layout: default
               </div>
               <div class="annual-report-text">
                 {{ page.Finances['Annual Report Text'] | markdownify }}
-                <a href="{{ page.Finances['Annual Report URL'] }}" class="btn btn-primary btn-block btn-download">{{ page.Finances['Annual Report Button'] }}</a>
+                <a class='piwik_download' href="{{ page.Finances['Annual Report URL'] }}" class="btn btn-primary btn-block btn-download">{{ page.Finances['Annual Report Button'] }}</a>
               </div>
             </div>
           </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -30,7 +30,7 @@
 
             <div class="home-highlights">
 
-              <div class="home-highlights-wrapper">
+              <div class="home-highlights-wrapper piwikTrackContent">
 
                 {% for home-project in page.Project %}
                   {% for project in site.projects %}


### PR DESCRIPTION
Fixes https://github.com/hotosm/matomo-tracking/issues/7

Changes: 
Adds a class to the PDF downloads in the community page to enable matomo download tracking. 


This is a WIP because (a) I wanted to show how simple it is to enable matomo link tracking on any `<a>` and (b) I am soliciting what other files should be tracked