### PR TITLE
Add new project page guidelines

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -161,7 +161,7 @@ defaults:
     tm_campaigns:
     - ''
     project_extent: ''
-    Google Drive: ''
+    Google Drive: 'https://drive.google.com/drive/folders/1p-dGhQsB4SSlucT3Yen1LlhqBj3Yvy-_'
     Map Products:
     - ''
     - ''

--- a/_docs/guidelines/04-add-project-page.md
+++ b/_docs/guidelines/04-add-project-page.md
@@ -14,7 +14,7 @@ Project pages are individual pages about current or historical projects at HOTOS
 
 ### 2. Decide if you want to have a map-based project view or static hero image
   
-  * Map-based will look like the screenshot above with a map view at the top of the page. 
+  * Map-based will have an interactive map view at the top of the page instead of an image.
   
   * Static hero image will not have map but only a large full-width image that you choose. 
 

--- a/_docs/guidelines/04-add-project-page.md
+++ b/_docs/guidelines/04-add-project-page.md
@@ -1,0 +1,47 @@
+---
+title: How to add Project Pages
+permalink: "/docs/guidelines/add-projects"
+Doc Type:
+  Is Guideline: true
+Apply Form Link: https://hotosm.slack.com/messages/hotosm-website/
+---
+
+Project pages are individual pages about current or historical projects at HOTOSM. New pages can be added via Siteleaf or Github. Please follow these general steps to add pages -- which can include maps and data to show what and where work is happening. Jump to the the [training document](https://docs.google.com/document/d/15sCWy-pgpTY0AvQcHQKamlXHZy9A7QXyfzk0vmcUHuY/edit?usp=sharing) for more detailed view with screenshots.
+
+## Overview of steps: 
+
+### 1. Create a new project via Siteleaf
+
+### 2. Decide if you want to have a map-based project view or static hero image
+  
+  * Map-based will look like the screenshot above with a map view at the top of the page. 
+  
+  * Static hero image will not have map but only a large full-width image that you choose. 
+
+
+### 3. If map-based:
+  
+  * Create a geojson
+  
+  * Upload your project area geojson to the public website Google Drive
+  
+  * Add any other public map products you want to share to the Google Drive
+  
+  * Fill out required metadata details on Siteleaf
+  
+    * Tasking Manager data you want to show on the map
+  
+    * Map or other project documents
+  
+    * Links to specific datasets or data portals
+  
+    * Links to tools used within the project
+
+
+### 4. If image-based:
+  
+  * Upload your image via Siteleaf
+  
+  * Fill out required metadata details
+
+For detailed commentary, please see the [training document](https://docs.google.com/document/d/15sCWy-pgpTY0AvQcHQKamlXHZy9A7QXyfzk0vmcUHuY/edit?usp=sharing).


### PR DESCRIPTION
Adds a new guideline for creating project pages. 

Changes: 
* adds a new markdown file for doc
* changes config to have a default google drive folder (related to Google Drive change we made for where project documents will be stored). 

Screenshots of the change: 

<img width="1425" alt="Humanitarian OpenStreetMap Team | How to add Project Pages 2019-07-17 18-11-05" src="https://user-images.githubusercontent.com/796838/61371277-96df9b00-a8be-11e9-9e22-8c44d8482b5b.png">
