### PR TITLE
Add noscript matomo tracking

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -3,6 +3,6 @@
 <script src="{{ "/js/main.js" | prepend: site.baseurl }}"></script>
 <script type="application/javascript">var site_id=1;</script>
 <script src="https://cdn.hotosm.org/tracking-v3.js"></script>
-<noscript><p><img src="https://matomo.hotosm.org/matomo.php?idsite=1&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="https://matomo.hotosm.org/matomo.php?idsite=17&amp;rec=1" style="border:0;" alt="" /></p></noscript>
 {% if page.layout == 'home' %}<script src="{{ "/js/stats.js" | prepend: site.baseurl }}"></script>{% endif %}
 {% if page.layout == 'country' %}<script src="{{ "/js/countries-stats.js" | prepend: site.baseurl }}"></script>{% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -3,5 +3,6 @@
 <script src="{{ "/js/main.js" | prepend: site.baseurl }}"></script>
 <script type="application/javascript">var site_id=1;</script>
 <script src="https://cdn.hotosm.org/tracking-v3.js"></script>
+<noscript><p><img src="https://matomo.hotosm.org/matomo.php?idsite=1&amp;rec=1" style="border:0;" alt="" /></p></noscript>
 {% if page.layout == 'home' %}<script src="{{ "/js/stats.js" | prepend: site.baseurl }}"></script>{% endif %}
 {% if page.layout == 'country' %}<script src="{{ "/js/countries-stats.js" | prepend: site.baseurl }}"></script>{% endif %}


### PR DESCRIPTION
Changes: 

Adds noscript tracking to hopefully catch more users who have disabled javascript. This is a first stop-gap measure before directly applying the matomo code (instead of using the custom tracking script)