### PR TITLE
fix news item image alignment on front page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -106,7 +106,7 @@
                 {% for post in site.posts limit:3 %}
                   <div class="news-preview-item item-{{ forloop.index }}">
                     <div class="news-preview-image">
-                      <img src="{{ post['Feature Image'] }}">
+                      <img {% if post['Is image top aligned'] %} style="object-position: top center" {% endif %} src="{{ post['Feature Image'] }}">
                     </div>
                     <div class="news-preview-details">
                      <p class="news-preview-meta">{{ post.date | date: '%e %b %Y' }}</p>


### PR DESCRIPTION
Fixes feature image issue on landing page. When the image looks better top aligned, and has the metadata for the post to top align on the blog post page, but it doesn't show up on the landing page: 

<img width="1417" alt="Humanitarian OpenStreetMap Team | Home 2019-09-13 15-28-39" src="https://user-images.githubusercontent.com/796838/64848571-bb948c80-d63b-11e9-94b6-b2c9964b59d9.png">
 
Changes: 
Added logic to check if post metadata has the top aligned flag. 

Screenshots of the change: 

<img width="1413" alt="Humanitarian OpenStreetMap Team | Home 2019-09-13 15-28-49" src="https://user-images.githubusercontent.com/796838/64848611-cea75c80-d63b-11e9-82c9-f4d42ae4c1cd.png">
