### PR TITLE
Fixed tooltip content to remove the API text. Closes #563

### DIFF
--- a/_layouts/country.html
+++ b/_layouts/country.html
@@ -220,7 +220,7 @@ layout: default
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Total-Map-Edits"></p>
       <p class="stat-title">Total Map Edits<sup>&#9432;</sup>
-        <span class="tooltiptext">Total number of edits using HOT Tasking Manager from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> API</span>
+        <span class="tooltiptext">Total number of edits using HOT Tasking Manager from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a></span>
       </p>
     </div>
     <div class="hr-v hide-sm"></div>
@@ -228,7 +228,7 @@ layout: default
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Buildings-Mapped"></p>
       <p class="stat-title">Buildings Mapped<sup>&#9432;</sup>
-        <span class="tooltiptext">Total number of buildings mapped using HOT Tasking Manager from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> API</span>
+        <span class="tooltiptext">Total number of buildings mapped using HOT Tasking Manager from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a></span>
       </p>
     </div>
     <div class="hr-v"></div>
@@ -236,7 +236,7 @@ layout: default
       <center><p class="loader"></p></center>
       <p class="stat-number" id="Roads-Mapped"></p>
       <p class="stat-title">Roads Mapped (KM)<sup>&#9432;</sup>
-        <span class="tooltiptext">Total length of roads mapped using HOT Tasking Manager from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> API</span>
+        <span class="tooltiptext">Total length of roads mapped using HOT Tasking Manager from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a></span>
       </p>
     </div>
   </div>
@@ -246,7 +246,7 @@ layout: default
       <center><p class="osm-loader"></p></center>
       <p class="stat-number" id="OSM-Community-Mappers"></p>
       <p class="stat-title">Community Mappers<sup>&#9432;</sup>
-        <span class="tooltiptext">Total number of OSM Mappers in {{ page.title }} from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> API</span>
+        <span class="tooltiptext">Total number of OSM Mappers in {{ page.title }} from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a></span>
       </p>
     </div>
     <div class="hr-v"></div>
@@ -254,7 +254,7 @@ layout: default
       <center><p class="osm-loader"></p></center>
       <p class="stat-number" id="OSM-Total-Map-Edits"></p>
       <p class="stat-title">Total Map Edits<sup>&#9432;</sup>
-        <span class="tooltiptext">Total number of OSM edits in {{ page.title }} from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> API</span>
+        <span class="tooltiptext">Total number of OSM edits in {{ page.title }} from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a></span>
       </p>
     </div>
     <div class="hr-v hide-sm"></div>
@@ -262,7 +262,7 @@ layout: default
       <center><p class="osm-loader"></p></center>
       <p class="stat-number" id="OSM-Buildings-Mapped"></p>
       <p class="stat-title">Buildings Mapped<sup>&#9432;</sup>
-        <span class="tooltiptext">Total number of OSM buildings in {{ page.title }} from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> API</span>
+        <span class="tooltiptext">Total number of OSM buildings in {{ page.title }} from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a></span>
       </p>
     </div>
     <div class="hr-v"></div>
@@ -270,7 +270,7 @@ layout: default
       <center><p class="osm-loader"></p></center>
       <p class="stat-number" id="OSM-Roads-Mapped"></p>
       <p class="stat-title">Roads Mapped (KM)<sup>&#9432;</sup>
-        <span class="tooltiptext">Total length of OSM roads in {{ page.title }} from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> API</span>
+        <span class="tooltiptext">Total length of OSM roads in {{ page.title }} from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a></span>
       </p>
     </div>
   </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -73,7 +73,7 @@
               <center><p class="loader"></p></center>
               <p class="stat-number" id="Total-Map-Edits"></p>
               <p class="stat-title">Total Map Edits<sup>&#9432;</sup>
-                <span class="tooltiptext">Total number of edits from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> API</span>
+                <span class="tooltiptext">Total number of edits from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a></span>
               </p>
             </div>
             <div class="hr-v hide-sm"></div>
@@ -81,7 +81,7 @@
               <center><p class="loader"></p></center>
               <p class="stat-number" id="Buildings-Mapped"></p>
               <p class="stat-title">Buildings Mapped<sup>&#9432;</sup>
-                <span class="tooltiptext">Total number of buildings mapped from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> API</span>
+                <span class="tooltiptext">Total number of buildings mapped from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a></span>
               </p>
             </div>
             <div class="hr-v"></div>
@@ -89,7 +89,7 @@
               <center><p class="loader"></p></center>
               <p class="stat-number" id="Roads-Mapped"></p>
               <p class="stat-title">Roads Mapped (KM)<sup>&#9432;</sup>
-                <span class="tooltiptext">Total length of roads mapped from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a> API</span>
+                <span class="tooltiptext">Total length of roads mapped from <a href="https://www.missingmaps.org/" target="_blank">Missing Maps</a></span>
               </p>
             </div>
           </div>


### PR DESCRIPTION
Fixes #563 

Changes: Removed the API text from the content of the tooltips


Screenshots of the change: 