### PR TITLE
Allow for volunteer/job postings with no deadline

### DIFF
--- a/_layouts/groups.html
+++ b/_layouts/groups.html
@@ -119,11 +119,11 @@ layout: default
             {% assign jobs_closed = site.jobs | sort: 'Deadline Date' | reverse %}
             {% for job in jobs_closed limit: 6 %}
               {% assign job_date = job['Deadline Date'] | date: '%Y%m%d' %}
-              {% if job_date < current_date %}
+              {% if job_date < current_date or job_date == null %}
               <a href="{{ job.url }}" class="module light link-through">
                 <div class="module-details">
                   <h3>{{ job.title }}</h3>
-                  <div class="module-text"><p>Location: <span>{{ job['Place of Work'] }}</span></p><p>Deadline: <span>{{ job['Deadline Date'] | date: '%d %B, %Y' }}</span></p></div>
+                  <div class="module-text"><p>Location: <span>{{ job['Place of Work'] }}</span></p><p>Deadline: <span>{{ job['Deadline Date'] | date: '%d %B, %Y' | default: "Until position is filled" }}</span></p></div>
                 </div>
               </a>
               {% endif %}
@@ -142,14 +142,14 @@ layout: default
   
               {% for volunteer-opportunities in volunteer-opportunities_sorted %}
                 {% assign volunteer-opportunities_date = volunteer-opportunities['Deadline Date'] | date: '%Y%m%d' %}
-                {% if volunteer-opportunities_date >= current_date %}  
+                {% if volunteer-opportunities_date >= current_date or volunteer-opportunities_date == null %}  
 
               <a href="{{ volunteer-opportunities.url }}" class="module light link-through">
                 <div class="module-details">
                   <h3>{{ volunteer-opportunities.title }}</h3>
                   <div class="module-text">
                     <p>Location: <span>{{ volunteer-opportunities['Place of Work'] | escape }}</span></p>
-                    <p>Deadline: <span>{{ volunteer-opportunities['Deadline Date'] | date: '%d %B, %Y' }}</span></p>
+                    <p>Deadline: <span>{{ volunteer-opportunities['Deadline Date'] | date: '%d %B, %Y' | default: "Until position is filled" }}</span></p>
                   </div>
                 </div>
               </a>

--- a/_volunteer-opportunities/hot-summit-website-volunteer.markdown
+++ b/_volunteer-opportunities/hot-summit-website-volunteer.markdown
@@ -1,7 +1,7 @@
 ---
 title: HOT Summit Website Volunteer
 date: 2020-02-21 07:38:00 Z
-Location: Remote
+Place of Work: Remote
 Apply Form Link: http://bit.ly/HOTvolunteer1
 layout: page
 ---


### PR DESCRIPTION
Changes: 
- Fixes the volunteer listing page for the HOT Summit Website position
- Adds a flag so that if there's no deadline listed, the job or volunteer content will still show up as "Until position is filled"

Screenshots of the change: 
![image](https://user-images.githubusercontent.com/1847818/75063092-2a5ef700-54b2-11ea-9da6-bf6711182a88.png)
