### PR TITLE
Add more filters to search json generation

### DIFF
--- a/_posts/2020-03-16-launching-number-map2020-for-improved-navigation-in-undermapped-regions.markdown
+++ b/_posts/2020-03-16-launching-number-map2020-for-improved-navigation-in-undermapped-regions.markdown
@@ -4,8 +4,9 @@ date: 2020-03-16 19:37:00 Z
 tags:
 - "#map2020"
 Summary Text: |-
-  ***UPDATE TO #MAP2020 DUE TO COVID-19***\
-  *With the ongoing situation of the Covid-19 outbreak in big parts of the world, we are asking #map2020 participants to follow their local governments’ respective guidelines. If you can’t go out and capture imagery due to the current situation, you can still participate in #map2020 by updating and improving OpenStreetMap by using imagery that already exists on [Mapillary](https://www.mapillary.com/app). The imagery should still be used to improve navigation in your chosen area. *
+  <strong>UPDATE TO #MAP2020 DUE TO COVID-19</strong></br>
+
+  <em>With the ongoing situation of the Covid-19 outbreak in big parts of the world,   we are asking #map2020 participants to follow their local governments’ respective guidelines. If you can’t go out and capture imagery due to the current situation, you can still participate in #map2020 by updating and improving OpenStreetMap by using imagery that already exists on <a href="https://www.mapillary.com/app">Mapillary</a>. The imagery should still be used to improve navigation in your chosen area.</em>
 Feature Image: "/uploads/2019-06-20-poor-road-conditions-ghana-af88e4.gif"
 Person: Gihan Hassanein
 Country:

--- a/search.json
+++ b/search.json
@@ -29,7 +29,7 @@ layout:
 {
 "type":"News",
 "title":"{{ post.title | escape }}",
-"summary":"{{ post['Summary Text'] | escape | truncatewords: 40 | strip | prepend: ' ' }}",
+"summary":"{{ post['Summary Text'] | escape | truncatewords: 40 | strip | strip_html | remove: "\" | prepend: ' ' }}",
 "subtitle":"{{ post.Person | join: ', ' | prepend: ' '}}",
 "url":"{{ site.url }}{{ post.url }}",
 "date":"{{ post.date }}"

--- a/updates/index.html
+++ b/updates/index.html
@@ -55,7 +55,7 @@ layout: default
             </div>
 
             <div class="news-list-summary-text">
-              <p>{{ post['Summary Text']}}</p>
+              <p>{{ post['Summary Text'] | newline_to_br }}</p>
             </div>
           </div>
 


### PR DESCRIPTION
Fixes Issue found on Slack where search wasn't working. This was due to a `\` character in a summary text field for a news post which wasn't being filtered out. 

Changes: 
- Adds filter to remove `\` characters from search.json generator
- formats summary text for https://www.hotosm.org/updates/launching-number-map2020-for-improved-navigation-in-undermapped-regions/
- Improves formatting for summary text in general


Screenshots of the change: 
Before:
![image](https://user-images.githubusercontent.com/1847818/78996780-54788100-7b13-11ea-9216-e3837c891300.png)

After:
![image](https://user-images.githubusercontent.com/1847818/78996758-4aef1900-7b13-11ea-802b-36f7f5e2f89a.png)
