### PR TITLE
Add annual report page

### DIFF
--- a/_annual-reports/annualreport2015.md
+++ b/_annual-reports/annualreport2015.md
@@ -1,0 +1,8 @@
+---
+title: 2015 Annual Report
+date: 2016-07-02 00:00:00 Z
+Link: https://hotosm.org/downloads/2015-Annual-Report.pdf
+Image: https://cdn.hotosm.org/storage/2015-Annual-Report.png
+---
+
+2015 was HOT's five year anniversary and a year of unprecedented growth with burgeoning community involvement, increased financial contributions, robust collaboration with multiple renowned partners and our largest and most complex disaster response activation ever in Nepal. We also held our first annual HOT Summit, addressing effective humanitarian and economic development uses of OpenStreetMap (OSM), the world’s premier source of open geospatial data. **Read more…**

--- a/_annual-reports/annualreport2016.md
+++ b/_annual-reports/annualreport2016.md
@@ -1,0 +1,8 @@
+---
+title: 2016 Annual Report
+date: 2017-07-02 00:00:00 Z
+Link: https://hotosm.org/downloads/2016-Annual-Report.pdf
+Image: https://cdn.hotosm.org/storage/2016-Annual-Report.png
+---
+
+In 2016 HOT joined the Global Alliance for Urban Crisis, and furthered our work in one of the world’s largest metropolitan areas (Jakarta, Indonesia) and Africa’s fastest-growing city (Dar es Salaam, Tanzania). HOT projects contributed to 11 different SDGs, and with a team of dedicated mappers in Uganda, HOT mapped more than 21,000 financial access points, fundamental to enabling local people to become more economically stable, prosperous and resilient. Our rapid response mapping community was activated for six disasters across Latin America and the Caribbean, Africa, and Asia. **Read more…**

--- a/_annual-reports/annualreport2017.md
+++ b/_annual-reports/annualreport2017.md
@@ -1,0 +1,8 @@
+---
+title: 2017 Annual Report
+date: 2018-07-02 00:00:00 Z
+Link: https://hotosm.org/downloads/2017-Annual-Report.pdf
+Image: https://cdn.hotosm.org/storage/2017-Annual-Report.png
+---
+
+In 2017 the HOT global community activated a total of 11 times for disaster responses, delivering critical base map data to humanitarian partner organizations. HOT also pioneered new approaches for working directly with Syrian refugees in Turkey and South Sudanese refugees in Uganda. By teaching use of OpenStreetMap to document services (and gaps) in their new countries, refugees and host community members took an active role in humanitarian response, pushing the system to become more accountable to the populations it seeks to serve. HOT also pioneered new methods of open data collection to make cities more resilient to natural hazards. **Read more…**

--- a/_annual-reports/annualreport2018.md
+++ b/_annual-reports/annualreport2018.md
@@ -1,0 +1,8 @@
+---
+title: 2018 Annual Report
+date: 2019-07-02 00:00:00 Z
+Link: https://hotosm.org/downloads/2018-Annual-Report.pdf
+Image: https://cdn.hotosm.org/storage/2018-Annual-Report.png
+---
+
+In 2018 the HOT community continued to build a map of the world where individuals and communities can represent themselves. This involved South Sudanese refugees mapping refugee settlements in Uganda, supporting displaced Venezuelans in the Caribbean, and mapping dense, flood-prone urban areas in Accra, Kampala, and Monrovia as part of Open Cities Africa. We also strived for greater inclusion of unrepresented communities, such as women and girls, by supporting these groups through providing Microgrants and the WomenConnect project in Peru and Tanzania. Our contributor community grew from 100,000 to nearly 160,000 people. **Read more…**

--- a/_annual-reports/annualreport2019.md
+++ b/_annual-reports/annualreport2019.md
@@ -1,0 +1,8 @@
+---
+title: 2019 Annual Report
+date: 2020-07-02 00:00:00 Z
+Link: https://annualreport2019.hotosm.org/
+Image: https://cdn.hotosm.org/storage/2019annualreportcover.png
+---
+
+The HOT community came together in 2019 at unprecedented levels to meet new humanitarian demands. Responding to Cyclone Idai, over 4,000 community members created maps used on the ground by the IFRC and MSF. Community grants in Peru, Tanzania and Zambia made a real impact on the digital gender divide, and new projects were launched in the Philippines to map some of the country’s largest cities and in the DRC to respond to the Ebola outbreak. Remote teams and individuals mapped every road in Indonesia, contributed to “Ayuda Venezuela”, mapped wildfires in Bolivia and areas affected by Hurricane Dorian in the Bahamas. By the end of 2019, we neared a major milestone - 200,000 mappers. **Read more…**

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,6 +30,7 @@
       <div class="nav-group">
         <a href="https://github.com/hotosm/hotosm-website/tree/gh-pages/downloads">Articles of Incorporation</a>
         <a href="https://github.com/hotosm/hotosm-website/tree/gh-pages/downloads">Bylaws</a>
+        <a href="/annual-reports">Annual Reports</a>
         <a href="/code-of-conduct">Code of conduct</a>
         <br>
         <br>

--- a/_layouts/groups.html
+++ b/_layouts/groups.html
@@ -90,6 +90,27 @@ layout: default
           {% endfor %}
         {% endif %}
 
+        {% if page.url contains "/annual-reports/" %}
+        {% assign reports = site.annual-reports | sort: 'date' %}
+        {% assign reports = reports | reverse %}
+          {% for group in reports %}
+            <a class="highlight-module secondary-highlight-module link-through light" href="{{ group['Link'] }}"  target="_blank">
+              <div class="highlight-details">
+                <div class="highlight-info">
+                  <h3>{{ group.title }}</h3>
+                  {{ group.content }}
+                </div>
+              </div>
+              {% if group['Image'] %}
+              <div class="highlight-image">
+                <img src="{{ group['Image'] }}">
+              </div>
+              {% endif %}
+            </a>
+          {% endfor %}
+        {% endif %}
+
+
         {% if page.url contains "/jobs/" %}
 
           <div class="group-section">

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -715,6 +715,7 @@ em {
   overflow: hidden;
   border-radius: 2px;
   margin-bottom: 24px;
+  text-decoration: none;
   background-color: shade($blue-dark, 20%);
   @media (max-width: $screen-md) {
     grid-template-rows: 460px;

--- a/annual-reports/index.markdown
+++ b/annual-reports/index.markdown
@@ -1,0 +1,5 @@
+---
+title: Annual Reports
+position: 0
+layout: groups
+---

--- a/community.markdown
+++ b/community.markdown
@@ -26,13 +26,13 @@ Finances:
     Access older financial reports and organization bylaws in our archive <a href="https://github.com/hotosm/hotosm-website/tree/gh-pages/downloads">here.</a>
   990 Report Button: Download 2018 990 PDF
   990 Report URL: "/uploads/HOTOSM%20990_PD%202018.PDF"
-  Annual Report Header: 2018 Annual Report
+  Annual Report Header: 2019 Annual Report
   Annual Report Text: "Each year we publish an annual report to recap projects and
     share updates from the community. We cover stories from our projects and share
     data about the successes and impact of the community. \n\nDownload our latest
-    annual report below. Access our annual report archive <a href=\"https://github.com/hotosm/hotosm-website/tree/gh-pages/downloads\">here.</a>"
-  Annual Report Button: Download 2018 PDF
-  Annual Report URL: "/downloads/2018-Annual-Report.pdf"
+    annual report below. Access our annual report archive <a href=\"https://hotosm.org/annual-reports/\">here.</a>"
+  Annual Report Button: Access 2019 Annual Report
+  Annual Report URL: "https://annualreport2019.hotosm.org/"
 layout: community
 ---
 


### PR DESCRIPTION
Changes: 
Adds new page for archiving and linking Annual Reports. Also changes the community page to host the 2019 report, and adds a footer link. 


Screenshots of the change: 
![image](https://user-images.githubusercontent.com/1847818/86609061-61253d80-bf79-11ea-8de6-9f7e0be2c832.png)
