### PR TITLE
Update countries-map.js 

### DIFF
--- a/js/countries-map.js
+++ b/js/countries-map.js
@@ -65,7 +65,7 @@ fetch('/aggregatedStats.json')
           var label = document.createElement('label')
           label.id = year + '-label';
           label.htmlFor = year;
-          label.appendChild(document.createTextNode(year + ' (' + count[year] + ')'));
+          label.appendChild(document.createTextNode(year));
           container.appendChild(checkbox);
           container.appendChild(label);
         });


### PR DESCRIPTION
update countries-map.js to remove undefined value in initial page load

Fixes #668 

Changes:
earlier:
Undefined value in year filter on country pages
now:
initial load only year are shown on clicking no of project will be shown

Screenshots of the change: 

![Screenshot from 2020-07-18 15-31-34](https://user-images.githubusercontent.com/59287619/87850351-2d4cff00-c90d-11ea-85c0-e5f855f4d309.png)

After click on year
![Screenshot from 2020-07-18 15-43-13](https://user-images.githubusercontent.com/59287619/87850407-9fbddf00-c90d-11ea-938b-b30308686e9e.png)
