### PR TITLE
Add annual reports to search function

### DIFF
--- a/search.json
+++ b/search.json
@@ -25,6 +25,16 @@ layout:
 "country":"{{ project.country | join: ', ' }}"
 },
 {% endfor %}
+{% for post in site.annual-reports reversed %}
+{
+"type":"Annual Reports",
+"title":"{{ post.title | escape }}",
+"summary":"{{ post.content | strip_html | escape | truncatewords: 40 | strip | remove: "\" | prepend: ' ' }}",
+"subtitle":" ",
+"url":"{{ site.url }}{{ post.url }}",
+"date":"{{ post.date }}"
+}, 
+{% endfor %}
 {% for post in site.posts %}
 {
 "type":"News",


### PR DESCRIPTION
Adds Annual Reports to search

Changes: 
The Annual Reports pages were not being indexed for search- so a user looking for them would only find a single News item from 2015. Now users can link directly to the report page. 


Screenshots of the change: 

![image](https://user-images.githubusercontent.com/1847818/90262543-6c8f4280-de1c-11ea-9d40-4f6f35fa6967.png)
