### PR TITLE
Fix user stats on home page

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -1,15 +1,12 @@
 // add stats to the home page
-$(document).ready(function () {
-  fetch('https://osmstats-api.hotosm.org/wildcard?key=hotosm-project-*')
-  .then(function (response) {
-    return response.json()
-  })
-  .then(function (jsonData) {
-    $('#Community-Mappers').text(formatedData(jsonData['users']));
-    $('#Total-Map-Edits').text(formatedData(jsonData['edits']));
-    $('#Buildings-Mapped').text(formatedData(jsonData['building_count_add']));
-    $('#Roads-Mapped').text(formatedData(Math.round(parseInt(jsonData['road_km_add']))));  
-    $('.loader').hide()
-  }
-  )
-})
+$(document).ready(function(){
+  $.get("https://tasking-manager-tm4-production-api.hotosm.org/api/v2/system/statistics/?abbreviated=true", function(data){
+    $('#Community-Mappers').text(formatedData(data['totalMappers']));
+  });
+  $.get("https://osmstats-api.hotosm.org/wildcard?key=hotosm-project-*", function(data){
+    $('#Total-Map-Edits').text(formatedData(data['edits']));
+    $('#Buildings-Mapped').text(formatedData(data['building_count_add']));
+    $('#Roads-Mapped').text(formatedData(Math.round(parseInt(data['road_km_add']))));
+   $('.loader').hide();
+  });
+});


### PR DESCRIPTION
Fixes #[Add issue number here]

Changes: 
Homepage Stats User numbers will show correctly, in line with tasks.hotosm.org.


Screenshots of the change: 

![image](https://user-images.githubusercontent.com/1847818/91884667-786c6880-ec54-11ea-903d-80889abde967.png)
