### PR TITLE
Fix Mozilla Observatory security header reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Finally, navigate to http://127.0.0.1:4000/ and you should see the new website!
 
 ![Website](https://user-images.githubusercontent.com/12103383/55768572-96f22280-5aa7-11e9-998d-9667f5d3a7dc.png)
 
-
 ## Website issues
 Please use the issue tracker at https://github.com/hotosm/hotosm-website/issues to report bugs, develop ideas, ask questions or give feedback. Thank you!
+
+## Security Notes
+
+- Github Pages does not support HSTS even when added in meta tags
+- Content-Security-Policy must be tweaked appropriately when new integrations are
+  added
+- Security header controls are absent in GH-Pages; So it's added as HTTP meta
+  tags in `_includes/head.html`

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,23 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta http-equiv="Content-Security-Policy"  
+    content="default-src 'self';
+             connect-src 'self' https://*.tiles.mapbox.com https://api.mapbox.com https://osmstats-api.hotosm.org https://tasking-manager-tm4-production-api.hotosm.org https://matomo.hotosm.org https://hotosm.bamboohr.com;
+             font-src 'self' https://fonts.gstatic.com https://themes.googleusercontent.com;
+             frame-src https://embed.ted.com https://www.youtube.com https://docs.google.com;
+             frame-ancestors 'self';
+             img-src 'self' data: https://s3.amazonaws.com http://hotwww.s3-website-us-east-1.amazonaws.com https://api.monosnap.com https://cdn.hotosm.org https://monosnap.com https://resources.bamboohr.com https://s3.amazonaws.com https://www.colorhexa.com;
+             object-src self;
+             manifest-src 'self';
+             media-src 'self';
+             worker-src blob:;
+             script-src 'self' 'unsafe-inline' https://ajax.googleapis.com https://api.tiles.mapbox.com https://cdn.hotosm.org https://matomo.hotosm.org https://hotosm.bamboohr.com;
+             style-src 'self' 'unsafe-inline' https://api.tiles.mapbox.com https://fonts.googleapis.com https://hotosm.bamboohr.com">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="SAMEORIGIN">
+  <meta http-equiv="X-XSS-Protection" content="1; mode=block">
+  <meta http-equiv="Strict-Transport-Security" content="max-age=63072000">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{{ site.title }} | {{ page.title }}</title>


### PR DESCRIPTION
JIRA issue: [HTR-70]; Github Issue: #27 in the tech repository

This patch adds security headers to fix the Mozilla Observatory reports
for missing security headers. I have added the following headers in their
recommended settings using HTTP meta tags.

X-Content-Type-Options
X-XSS-Protection
X-Frame-Options
Strict-Transport-Security
Content-Security-Policy

For Content-Security-Policy, I have used Mozilla Labs - CSP generator
to scan the site and generate a base-policy that I then tweaked with
instructions from Mapbox, Google and Matomo documentations.

The meta tags will stand-in for the lack of header control in Github Pages

SECURITY NOTE:

Github pages does not honor Strict-Transport-Security meta-tag; This will
trigger failures in HTTPS quality checks. This is out of our control.