### PR TITLE
Add missing header directives for mapboxgl

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,11 +7,12 @@
              font-src 'self' https://fonts.gstatic.com https://themes.googleusercontent.com;
              frame-src https://embed.ted.com https://www.youtube.com https://docs.google.com;
              frame-ancestors 'self';
-             img-src 'self' data: https://s3.amazonaws.com http://hotwww.s3-website-us-east-1.amazonaws.com https://api.monosnap.com https://cdn.hotosm.org https://monosnap.com https://resources.bamboohr.com https://s3.amazonaws.com https://www.colorhexa.com;
+             img-src 'self' data: blob: https://s3.amazonaws.com http://hotwww.s3-website-us-east-1.amazonaws.com https://api.monosnap.com https://cdn.hotosm.org https://monosnap.com https://resources.bamboohr.com https://s3.amazonaws.com https://www.colorhexa.com;
              object-src self;
              manifest-src 'self';
              media-src 'self';
              worker-src blob:;
+             child-src blob: ;
              script-src 'self' 'unsafe-inline' https://ajax.googleapis.com https://api.tiles.mapbox.com https://cdn.hotosm.org https://matomo.hotosm.org https://hotosm.bamboohr.com;
              style-src 'self' 'unsafe-inline' https://api.tiles.mapbox.com https://fonts.googleapis.com https://hotosm.bamboohr.com">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">


### PR DESCRIPTION
Fixes issue raised by @willemarcel on Slack

Changes: 
- add missing directives for the Mapboxgl maps to work, via https://docs.mapbox.com/mapbox-gl-js/api/#csp-directives
