### PR TITLE
Change postal address for OpenGov Hub where HOT office is located

### DIFF
--- a/_where-we-work/united-states.md
+++ b/_where-we-work/united-states.md
@@ -3,8 +3,8 @@ title: United States
 Location:
   Location Name: OpenGov Hub
   Address: |-
-    1110 Vermont Ave. NW <br>
-    Suite 500 <br>
+    1100 13th Street NW <br>
+    Suite 800 <br>
     Washington, DC 20005
   Map Link: https://www.openstreetmap.org/node/4489226846
 continent: NA

--- a/contact.markdown
+++ b/contact.markdown
@@ -20,7 +20,7 @@ Office Locations:
     **United States**
 
     [OpenGov Hub](https://www.openstreetmap.org/node/4489226846)
-    1110 Vermont Ave. NW Suite 500
+    1100 13th Street NW Suite 800
     Washington, D.C. 20005
   - "**Indonesia**\n\n[HOT Indonesia Office](https://www.openstreetmap.org/?mlat=-6.2367019057273865&mlon=106.85639351606369#map=19/-6.23670/106.85639)\nJalan
     Tebet Timur III/i No. 4 \nTebet, Jakarta 12820"

--- a/privacy.md
+++ b/privacy.md
@@ -154,6 +154,6 @@ We may modify this Privacy Policy from time to time.  All such changes will be r
 
 If you have a question about this Privacy Policy, please contact us at [info@hotosm.org](mailto:info@hotosm.org).  Additional contact details are as follows:
 
-1110 Vermont Avenue NW  
-Suite 500  
-Washington, D.C. 20005  
+1100 13th Street NW
+Suite 800
+Washington, D.C. 20005


### PR DESCRIPTION
- Old Address:
  1110 Vermont Ave. NW Suite 500 Washington, D.C. 20005

- New Address:
  1100 13th Street NW Suite 800 Washington, D.C. 20005

The OSM node corresponding to the location for the suite has been
changed to the appropriate location as well.
