### PR TITLE
Add OAM RFP Proposal

### DIFF
--- a/_rfps/oam-v2-design.md
+++ b/_rfps/oam-v2-design.md
@@ -1,0 +1,25 @@
+---
+title: RFP - OpenAerialMap v2 Design
+date: 2021-10-27 19:47:00 Z
+Deadline Date: 2021-11-15 23:59:00 Z
+Apply Form Link: https://cdn.hotosm.org/website/OpenAerialMap-v2-Design-SoW.pdf
+Page Contact:
+  Contact Email: info@openaerialmap.org
+  Label: Submission Email
+---
+
+The Humanitarian OpenStreetMap Team is soliciting proposals for a design consultant to guide the next stage of development for [OpenAerialMap](https://openaerialmap.org).
+
+The [scope of work is available here](https://cdn.hotosm.org/website/OpenAerialMap-v2-Design-SoW.pdf).
+
+To apply, please send a proposal in ODF or PDF format (not exceeding 20 pages) to info@openaerialmap.org that includes the following information by November 15, 2021:
+
+- Consultant presentation
+- Previous relevant experience
+- Technical approach for conducting the activities
+- Timeline for implementation
+- Estimated budget
+
+Individual CVs/resumes can be attached as supporting evidence of the required experience.
+
+If you have any questions, please direct them to info@openaerialmap.org.

--- a/_rfps/oam-v2-design.md
+++ b/_rfps/oam-v2-design.md
@@ -1,7 +1,7 @@
 ---
 title: RFP - OpenAerialMap v2 Design
 date: 2021-10-27 19:47:00 Z
-Deadline Date: 2021-11-15 23:59:00 Z
+Deadline Date: 2021-11-21 23:59:00 Z
 Apply Form Link: https://cdn.hotosm.org/website/OpenAerialMap-v2-Design-SoW.pdf
 Page Contact:
   Contact Email: info@openaerialmap.org
@@ -12,7 +12,7 @@ The Humanitarian OpenStreetMap Team is soliciting proposals for a design consult
 
 The [scope of work is available here](https://cdn.hotosm.org/website/OpenAerialMap-v2-Design-SoW.pdf).
 
-To apply, please send a proposal in ODF or PDF format (not exceeding 20 pages) to info@openaerialmap.org that includes the following information by November 15, 2021:
+To apply, please send a proposal in ODF or PDF format (not exceeding 20 pages) to info@openaerialmap.org that includes the following information by November 21, 2021:
 
 - Consultant presentation
 - Previous relevant experience


### PR DESCRIPTION

Changes: 
Adds OAM RFP Proposal page. PDF available at https://cdn.hotosm.org/website/OpenAerialMap-v2-Design-SoW.pdf


Screenshots of the change:
Page:
![Screenshot_2021-10-26 Humanitarian OpenStreetMap Team RFP - OpenAerialMap v2 Design](https://user-images.githubusercontent.com/1847818/138894050-bae6ec22-9f5b-40e9-8ec7-0b33111e6eae.png)
 
RFP Index:
![Screenshot_2021-10-26 Humanitarian OpenStreetMap Team RFPs](https://user-images.githubusercontent.com/1847818/138894119-7e64bfda-470a-4c76-907b-1880498483c5.png)
 
