### PR TITLE
Add LATAM Hub page

### DIFF
--- a/_hubs/latam-hub.md
+++ b/_hubs/latam-hub.md
@@ -2,6 +2,6 @@
 title: LATAM Hub
 position: 0
 layout: hub-page
-embed-link: https://stories.hotosm.org/latam-homepage_draft/embed.js
+embed-link: https://stories.hotosm.org/latam-homepage/embed.js
 ---
 

--- a/_hubs/latam-hub.md
+++ b/_hubs/latam-hub.md
@@ -1,0 +1,7 @@
+---
+title: LATAM Hub
+position: 0
+layout: hub-page
+embed-link: https://stories.hotosm.org/latam-homepage_draft/embed.js
+---
+

--- a/_layouts/hubs.html
+++ b/_layouts/hubs.html
@@ -18,8 +18,8 @@ layout: default
     <div class="container">
       <h2 class="partner-subtitle">{{ page.blocktitle }}</h2>
 
-      <div class="module-group top-image-auto">
-        <a class="module link-through light" href="{{ page.block-1.Link }}" id="support-programs">
+      <div class="module-group-hubs top-image-auto">
+        <a class="module link-through light" href="{{ page.block-1.Link }}" id="support-programs" target="_blank">
           <div class="module-image">
             <img src="{{ page.block-1.Image }}">
           </div>
@@ -29,7 +29,7 @@ layout: default
             <p class="module-cta">{{ page.block-1.Action-text }}</p>
           </div>
         </a>
-        <a class="module link-through light" href="{{ page.block-2.Link }}" id="support-programs">
+        <a class="module link-through light" href="{{ page.block-2.Link }}" id="support-programs" target="_blank">
           <div class="module-image">
             <img src="{{ page.block-2.Image }}">
           </div>
@@ -39,7 +39,7 @@ layout: default
             <p class="module-cta">{{ page.block-2.Action-text  }}</p>
           </div>
         </a>
-        <a class="module link-through light" href="{{ page.block-3.Link }}" id="support-programs">
+        <a class="module link-through light" href="{{ page.block-3.Link }}" id="support-programs" target="_blank">
           <div class="module-image">
             <img src="{{ page.block-3.Image }}">
           </div>
@@ -47,6 +47,16 @@ layout: default
             <!-- <h3>{{ page.block-3.Title | markdownify }}</h3> -->
             <div class="module-text">{{ page.block-3.Text | markdownify }}</div>
             <p class="module-cta">{{ page.block-3.Action-text  }}</p>
+          </div>
+        </a>
+        <a class="module link-through light" href="{{ page.block-4.Link }}" id="support-programs" target="_blank">
+          <div class="module-image">
+            <img src="{{ page.block-4.Image }}">
+          </div>
+          <div class="module-details">
+            <!-- <h3>{{ page.block-3.Title | markdownify }}</h3> -->
+            <div class="module-text">{{ page.block-4.Text | markdownify }}</div>
+            <p class="module-cta">{{ page.block-4.Action-text  }}</p>
           </div>
         </a>
       </div>

--- a/_layouts/hubs.html
+++ b/_layouts/hubs.html
@@ -19,7 +19,7 @@ layout: default
       <h2 class="partner-subtitle">{{ page.blocktitle }}</h2>
 
       <div class="module-group-hubs top-image-auto">
-        <a class="module link-through light" href="{{ page.block-1.Link }}" id="support-programs" target="_blank">
+        <a class="module link-through light" href="{{ page.block-1.Link }}" id="support-programs">
           <div class="module-image">
             <img src="{{ page.block-1.Image }}">
           </div>
@@ -29,7 +29,7 @@ layout: default
             <p class="module-cta">{{ page.block-1.Action-text }}</p>
           </div>
         </a>
-        <a class="module link-through light" href="{{ page.block-2.Link }}" id="support-programs" target="_blank">
+        <a class="module link-through light" href="{{ page.block-2.Link }}" id="support-programs" >
           <div class="module-image">
             <img src="{{ page.block-2.Image }}">
           </div>
@@ -39,7 +39,7 @@ layout: default
             <p class="module-cta">{{ page.block-2.Action-text  }}</p>
           </div>
         </a>
-        <a class="module link-through light" href="{{ page.block-3.Link }}" id="support-programs" target="_blank">
+        <a class="module link-through light" href="{{ page.block-3.Link }}" id="support-programs" >
           <div class="module-image">
             <img src="{{ page.block-3.Image }}">
           </div>
@@ -49,7 +49,7 @@ layout: default
             <p class="module-cta">{{ page.block-3.Action-text  }}</p>
           </div>
         </a>
-        <a class="module link-through light" href="{{ page.block-4.Link }}" id="support-programs" target="_blank">
+        <a class="module link-through light" href="{{ page.block-4.Link }}" id="support-programs" >
           <div class="module-image">
             <img src="{{ page.block-4.Image }}">
           </div>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -724,6 +724,24 @@ em {
   }
 }
 
+.module-group-hubs {
+  display: grid;
+  grid-gap: 24px;
+  margin-bottom: 24px;
+  &.grid-two-rows {
+    grid-template-rows: repeat(2, 1fr);
+  }
+  @media (min-width: $screen-sm) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  @media (min-width: $screen-xs) and (max-width: $screen-sm) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  @media (max-width: $screen-xs) {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}
+
 .module-header {
   margin-bottom: 24px;
 }

--- a/hubs/index.markdown
+++ b/hubs/index.markdown
@@ -14,7 +14,7 @@ block-2:
     <br /><br />We envision a future where all people in Eastern and Southern Africa have the opportunity to contribute to and use open mapping processes and open data in their everyday lives.
   Action-text: Learn More
   Image: "/uploads/HOT_OMH_ESA_English_Logo_REV_COLOUR.png"
-  Link: https://stories.hotosm.org/esa-homepage/index.html
+  Link: esa-hub
 block-3:
   Title: West & Northern Africa
   Text: "<strong>The Open Mapping Hub - West and Northern Africa </strong> engages
@@ -27,7 +27,7 @@ block-3:
     their own purposes.<br /><br />"
   Action-text: Learn More
   Image: "/uploads/HOT_OMH_WNA_English_Logo_REV_COLOUR.png"
-  Link: https://stories.hotosm.org/wna-homepage/index.html
+  Link: wna-hub
 block-1:
   Title: Asia Pacific
   Text: "<strong>The Open Mapping Hub - Asia-Pacific</strong> is working to create
@@ -41,14 +41,14 @@ block-1:
     movement."
   Action-text: Learn More
   Image: "/uploads/HOT_OMH_Asia_Pacific_Logo_REV_COLOUR.png"
-  Link: https://stories.hotosm.org/ap-homepage/index.html
+  Link: asia-pacific-hub
 block-4:
   Title: LATAM Hub
   Text: "<strong>El Hub de mapeo abierto - América Latina</strong> se encuentra en la “Fase Alpha” ¿Qué es esto? Es una etapa previa en la cual estamos diseñando y probando actividades que, no sólo aporten valor a la gente, sino que también ayuden a HOT, las comunidades y otros actores del mapeo abierto de la región a colaborar juntos y así co-diseñar lo que un Hub de Mapeo Abierto al servicio de diecinueve países de América Latina podría ser y hacer.<br /><br />
   Esperamos en el futuro inmediato pasarle la antorcha al Hub y entregarle una sólida red de relaciones a distinto nivel en toda la región, un grupo de proyectos realizados o en ejecución que demuestren el valor que puede aportar el Hub a las comunidades, y por ende una creciente reputación positiva. También unos modelos probados de colaboración que luego el Hub podrá optimizar y sumar a sus propios modelos."
   Action-text: Learn More
   Image: "https://cdn.hotosm.org/website/HOT_OMH_LATAM_Spanish_Logo_REV_COLOUR.png"
-  Link: https://stories.hotosm.org/latam-homepage_draft/index.html
+  Link: latam-hub
 layout: hubs
 ---
 

--- a/hubs/index.markdown
+++ b/hubs/index.markdown
@@ -42,6 +42,13 @@ block-1:
   Action-text: Learn More
   Image: "/uploads/HOT_OMH_Asia_Pacific_Logo_REV_COLOUR.png"
   Link: https://stories.hotosm.org/ap-homepage/index.html
+block-4:
+  Title: LATAM Hub
+  Text: "<strong>El Hub de mapeo abierto - América Latina</strong> se encuentra en la “Fase Alpha” ¿Qué es esto? Es una etapa previa en la cual estamos diseñando y probando actividades que, no sólo aporten valor a la gente, sino que también ayuden a HOT, las comunidades y otros actores del mapeo abierto de la región a colaborar juntos y así co-diseñar lo que un Hub de Mapeo Abierto al servicio de diecinueve países de América Latina podría ser y hacer.<br /><br />
+  Esperamos en el futuro inmediato pasarle la antorcha al Hub y entregarle una sólida red de relaciones a distinto nivel en toda la región, un grupo de proyectos realizados o en ejecución que demuestren el valor que puede aportar el Hub a las comunidades, y por ende una creciente reputación positiva. También unos modelos probados de colaboración que luego el Hub podrá optimizar y sumar a sus propios modelos."
+  Action-text: Learn More
+  Image: "https://cdn.hotosm.org/website/HOT_OMH_LATAM_Spanish_Logo_REV_COLOUR.png"
+  Link: https://stories.hotosm.org/latam-homepage_draft/index.html
 layout: hubs
 ---
 


### PR DESCRIPTION
Changes: 
Update layout of hubs page to include 4 blocks, and add LATAM Hub page. 


Screenshots of the change: 
![Screen Shot 2022-04-22 at 10 12 07](https://user-images.githubusercontent.com/1847818/164734714-8488b7d2-45eb-4f06-a9b1-773dfa55ba8f.png)

