### PR TITLE
Updating home page StartMapping button CTA link

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -18,7 +18,7 @@
                 <a href="/what-we-do" class="btn btn-primary btn-lg btn-chevron btn-block">
                   Learn about what we do
                 </a>
-                <a href="https://tasks.hotosm.org/learn" class="btn btn-info btn-lg btn-chevron btn-block class start-mapping-btn ttu font-headline">
+                <a href="https://tasks.hotosm.org/explore" class="btn btn-info btn-lg btn-chevron btn-block class start-mapping-btn ttu font-headline">
                   Start mapping
                 </a>
               </div>


### PR DESCRIPTION
The previous link shows a `Page Not Found` error. The updated link redirects to the `explore` section in the page.


Fixes #819 

Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Modified the links for the homepage Start Mapping button

Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->