### PR TITLE
Make project pages content left-aligned

### DIFF
--- a/_layouts/project-item.html
+++ b/_layouts/project-item.html
@@ -142,9 +142,9 @@ layout: default
                             document archive >></a>
                     </div>
                     {% endif %}
+                    {% if page['project_extent'] != '' %}
                     <div class="panel-wrapper">
 
-                    {% if page['project_extent'] != '' %}
                         <button class="more" id="more" onclick="content('more')">Read more</button>
                         <button class="less" id="less" onclick="content('less')" style="display:none;">Show less</button>
 
@@ -157,12 +157,12 @@ layout: default
 
                         <div class="fade"></div>
                         
-                        {% else %} 
+                   </div>
+                    {% else %} 
 
-                            {{ content }}
+                    {{ content }}
 
                     {% endif %}
-                   </div>
                 </div>
             </div>
 


### PR DESCRIPTION


Changes: 
I moved the project pages content outside of the panel-wrapper div so that it would not be affected by that styling anymore. 

Screenshots of the change: 
New: 
![image](https://user-images.githubusercontent.com/1847818/236924001-d664b4e3-5cdb-4cab-8b45-82d29d044380.png)
