### PR TITLE
Update links of Rapid

### DIFF
--- a/_tools/rapid.markdown
+++ b/_tools/rapid.markdown
@@ -2,7 +2,7 @@
 title: RapiD
 date: 2021-03-23 10:31:00 Z
 position: 6
-Tool URL: https://mapwith.ai/rapid/
+Tool URL: https://mapwith.ai/rapid
 Tool id: "#2"
 ---
 

--- a/tools-and-data.markdown
+++ b/tools-and-data.markdown
@@ -65,7 +65,7 @@ Block 4:
   - Name: Portable OpenStreetMap (POSM)
     URL: http://posm.io/
   - Name: RapiD
-    URL: https://mapwith.ai/rapid/
+    URL: https://mapwith.ai/rapid
 Block 5:
   Header: Access OSM Data
   Text: To access OSM data, HOT built the Export Tool which allows anyone to create


### PR DESCRIPTION
Fixes #826 

Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Fix links of Rapid.

Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->
Cannot access with the last /
![image](https://github.com/hotosm/hotosm-website/assets/1407941/50b6fe41-e20a-4de8-91c4-8a4ff07c891f)

It works without the last /, and the URL was redirected.
<img width="836" alt="image" src="https://github.com/hotosm/hotosm-website/assets/1407941/b1efd173-82ca-41eb-9204-1ff9934ba554">

As in issue #826,  is https://rapideditor.org/ their new domain?
I checked with https://rapideditor.org/edit, and it worked.

I wonder if we needed to set a new URL.