### PR TITLE
Quick fix sm xsm screen

### DIFF
--- a/_layouts/open-data-solutions.html
+++ b/_layouts/open-data-solutions.html
@@ -14,7 +14,7 @@ layout: default
                       <div>
                         <img src="{{ page.Field-mapping-image }}"  style="max-width: 140%; filter: brightness(70%);">
                       </div>
-                    <div class="home-highlight-title2" style="bottom: 50px; left: 100px;">
+                    <div class="home-highlight-title2 block-data-solutions-title" style="bottom: 50px;">
                       <div class="container">
                           <header class="tools-header header-subnav" style="margin: 32px 560px 64px 0px;">
                             <h1 style="color: white; font-family: Barlow Condensed, sans-serif; font-weight: bold; text-transform: uppercase; letter-spacing: .045em; line-height: 1.15; font-size: 4rem;">{{ page.title }}</h1>
@@ -36,7 +36,7 @@ layout: default
 
 
               <div >
-                <div  style="padding: 12px 140px 32px;">
+                <div  class="block-data-solutions">
                   <h4 style="font-family: Barlow Condensed, sans-serif; font-weight: bold; text-transform: uppercase; letter-spacing: .045em; line-height: 1.15; font-size: 1.5rem; color: black;">At HOT, we use a combination of internally and externally developed tools to create, access, manage, analyze, and share open map data that serves our partners and local communities.</h4>
                   <br>
                   <p>{{ page.Intro.Text }}</p>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -6099,7 +6099,22 @@ th, td {
   }
 }
 
+.block-data-solutions {
+  margin: 32px 150px 64px 150px;
+  @media (max-width: $screen-sm) {
+    margin: 0px 15px 0px 15px;
+  }
+}
 
+.block-data-solutions-title {
+  left: 100px;
+  @media (max-width: $screen-sm) {
+    left: 100px;
+  }
+  @media (max-width: $screen-xs) {
+    left: 0px;
+  }
+}
 
 .home-highlight4 {
   display: block;


### PR DESCRIPTION
Fixes #[Add issue number here]

Changes: 

Added screen responsivness to the Open Data Solutions page to improve readability on sm and xsm screens. 
Text now has more words per line and just a bit of padding. 

<img width="308" alt="image" src="https://github.com/hotosm/hotosm-website/assets/77023236/57acf0e1-542d-45e7-b810-8b749d946daa">
