### PR TITLE
page(update): removed events from carrousel

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -94,7 +94,7 @@
             </div>  
           </div>
         </div>
-        <div class="slide">
+        <!-- <div class="slide">
           {% for home-news in page.News limit:3 %}
                   {% for project in site.projects %}
                   {% if home-news == project.title %}
@@ -107,7 +107,7 @@
           {% endfor %}
             </div>  
           </div>
-        </div>
+        </div> -->
       </div>
 
       <div class="slider-nav">
@@ -115,7 +115,7 @@
         <a href="#slide-2" data-slide="1"></a>
         <a href="#slide-3" data-slide="2"></a>
         <a href="#slide-4" data-slide="3"></a>
-        <a href="#slide-5" data-slide="4"></a>
+        <!-- <a href="#slide-5" data-slide="4"></a> -->
       </div>
 
       <!-- Arrows for navigation -->


### PR DESCRIPTION
Changes: 
- Removed "events" from the slides, as it is seldomly used and not up to date. I will comment out instead of deleting just in case we want to revive it in the near future. 

(requested by Leadership)