### PR TITLE
fAIr production link fixes

### DIFF
--- a/_tools/fair.markdown
+++ b/_tools/fair.markdown
@@ -2,7 +2,7 @@
 title: fAIr
 date: 2023-03-11 10:37:00 Z
 position: 3
-Tool URL: https://fair-dev.hotosm.org/
+Tool URL: https://fair.hotosm.org/
 Tool id: "#2"
 sitemap: false
 ---

--- a/open-data-solutions.markdown
+++ b/open-data-solutions.markdown
@@ -99,7 +99,7 @@ Fair:
   Image: 
   Tools:
   - Name: Website
-    URL: https://fair-dev.hotosm.org/
+    URL: https://fair.hotosm.org/
   - Name: Dev Docs
     URL: https://docs.hotosm.org/
   - Name: GitHub

--- a/tech-suite.markdown
+++ b/tech-suite.markdown
@@ -31,7 +31,7 @@ Fair:
   Image: https://www.hotosm.org/uploads/fair-demo.png
   Tools:
   - Name: Learn More
-    URL: https://fair-dev.hotosm.org/
+    URL: https://fair.hotosm.org/
 Export-tool:
   Header: HOT Export Tool
   Text: The HOT Export Tool is an open service that creates customized extracts of


### PR DESCRIPTION
Changes: 
updating fAIr link to production env in the hotosm website in 3 locations:
1- fAIr main page
2- Tech suite page
3- Open data solutions page 
